### PR TITLE
Add GitHub CLI integration (v0.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,38 @@ Always run `make check` before committing changes.
 - Use `@work` decorator for async operations that update UI
 - CSS is defined in `theme.py` as `APP_CSS`
 
+### Async Operations & Reactive UI
+
+**IMPORTANT:** Never block the UI with slow operations. The app must start instantly.
+
+For any operation that may take time (CLI calls, network requests, file I/O):
+1. Render UI immediately with a loading state ("Loading...", "Checking...")
+2. Dispatch work to a background task using `@work` decorator
+3. When the task completes, update the UI reactively
+
+Example pattern:
+```python
+# In compose(), show loading state:
+yield Label("Loading...", id="my-loading")
+
+# In on_mount() or elsewhere, dispatch background work:
+self._fetch_data()
+
+@work
+async def _fetch_data(self) -> None:
+    data = await slow_operation()
+    # Update UI when ready
+    self.query_one("#my-loading").update(f"Result: {data}")
+```
+
+This applies to:
+- External CLI integrations (gh, git, etc.)
+- Network requests
+- File system operations that may be slow
+- Any operation that could fail or hang
+
+The UI should always remain responsive. Users should never see the app freeze.
+
 ### Services
 - Services are singletons accessed via `get_*_service()` functions
 - State is persisted automatically via `_save_state()` methods

--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,3 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -14,6 +14,27 @@ from forestui import __version__
 INSTALL_DIR = Path.home() / ".forestui-install"
 
 
+def is_dev_mode() -> bool:
+    """Check if running from source (dev mode) vs installed."""
+    # If running from within the install dir, it's installed
+    try:
+        cli_path = Path(__file__).resolve()
+        install_path = INSTALL_DIR.resolve()
+        return not str(cli_path).startswith(str(install_path))
+    except Exception:
+        return False
+
+
+def get_window_name() -> str:
+    """Get the tmux window name based on install/dev mode."""
+    if is_dev_mode():
+        from datetime import datetime
+
+        hhmm = datetime.now().strftime("%H%M")
+        return f"forestui-dev-{hhmm}"
+    return "forestui"
+
+
 def rename_tmux_window(name: str) -> None:
     """Rename the current tmux window."""
     from forestui.services.tmux import get_tmux_service
@@ -136,7 +157,7 @@ def main(forest_path: str | None, no_self_update: bool, debug_mode: bool) -> Non
     if no_self_update:
         os.environ["FORESTUI_NO_AUTO_UPDATE"] = "1"
 
-    rename_tmux_window("forestui")
+    rename_tmux_window(get_window_name())
 
     # Import here to avoid circular imports and speed up --help/--version
     from forestui.app import run_app

--- a/forestui/services/__init__.py
+++ b/forestui/services/__init__.py
@@ -2,7 +2,15 @@
 
 from forestui.services.claude_session import ClaudeSessionService
 from forestui.services.git import GitService
+from forestui.services.github import GitHubService, get_github_service
 from forestui.services.settings import SettingsService
 from forestui.services.tmux import TmuxService
 
-__all__ = ["ClaudeSessionService", "GitService", "SettingsService", "TmuxService"]
+__all__ = [
+    "ClaudeSessionService",
+    "GitHubService",
+    "GitService",
+    "SettingsService",
+    "TmuxService",
+    "get_github_service",
+]

--- a/forestui/services/github.py
+++ b/forestui/services/github.py
@@ -1,0 +1,242 @@
+"""GitHub CLI service for interacting with gh."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NamedTuple
+
+from forestui.models import GitHubIssue, GitHubLabel, GitHubUser
+
+
+class IssueCache(NamedTuple):
+    """Cached issues with timestamp."""
+
+    issues: list[GitHubIssue]
+    fetched_at: datetime
+
+
+class GitHubService:
+    """Service for interacting with GitHub via gh CLI."""
+
+    _instance: GitHubService | None = None
+    CACHE_TTL_SECONDS: int = 300  # 5 minutes
+
+    _cache: dict[str, IssueCache]
+    _auth_status: str | None
+    _username: str | None
+
+    def __new__(cls) -> GitHubService:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._cache = {}
+            cls._instance._auth_status = None
+            cls._instance._username = None
+        return cls._instance
+
+    @staticmethod
+    async def _run_gh(
+        *args: str, cwd: str | Path | None = None
+    ) -> tuple[int, str, str]:
+        """Run a gh command and return (exit_code, stdout, stderr)."""
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "gh",
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(cwd) if cwd else None,
+            )
+            stdout, stderr = await process.communicate()
+            return (
+                process.returncode or 0,
+                stdout.decode().strip(),
+                stderr.decode().strip(),
+            )
+        except FileNotFoundError:
+            return (-1, "", "gh not found")
+
+    async def get_auth_status(self) -> tuple[str, str | None]:
+        """Get GitHub CLI authentication status and username.
+
+        Returns: (status, username) where status is "authenticated", "not_authenticated", or "not_installed"
+        """
+        if self._auth_status is not None:
+            return self._auth_status, self._username
+
+        code, _stdout, _ = await self._run_gh("auth", "status")
+        if code == -1:
+            self._auth_status = "not_installed"
+            self._username = None
+        elif code == 0:
+            self._auth_status = "authenticated"
+            # Get username
+            code, stdout, _ = await self._run_gh("api", "user", "--jq", ".login")
+            self._username = stdout if code == 0 and stdout else None
+        else:
+            self._auth_status = "not_authenticated"
+            self._username = None
+        return self._auth_status, self._username
+
+    async def get_repo_info(self, path: str | Path) -> tuple[str, str] | None:
+        """Get (owner, repo) for a git repository path. Returns None if not a GitHub repo."""
+        code, stdout, _ = await self._run_gh(
+            "repo", "view", "--json", "owner,name", cwd=path
+        )
+        if code != 0 or not stdout:
+            return None
+        try:
+            data = json.loads(stdout)
+            return (data["owner"]["login"], data["name"])
+        except (json.JSONDecodeError, KeyError):
+            return None
+
+    async def list_issues(
+        self,
+        path: str | Path,
+        assigned_to_me: bool = True,
+        authored_by_me: bool = True,
+        limit: int = 10,
+        use_cache: bool = True,
+    ) -> list[GitHubIssue]:
+        """List GitHub issues for the repository at path."""
+        # Check auth first
+        auth, _ = await self.get_auth_status()
+        if auth != "authenticated":
+            return []
+
+        repo_info = await self.get_repo_info(path)
+        if not repo_info:
+            return []
+
+        cache_key = f"{repo_info[0]}/{repo_info[1]}"
+
+        # Check cache
+        if use_cache and cache_key in self._cache:
+            cached = self._cache[cache_key]
+            age = (datetime.now(UTC) - cached.fetched_at).total_seconds()
+            if age < self.CACHE_TTL_SECONDS:
+                return cached.issues
+
+        # Fetch from GitHub
+        issues = await self._fetch_issues(path, assigned_to_me, authored_by_me, limit)
+
+        # Update cache
+        self._cache[cache_key] = IssueCache(issues=issues, fetched_at=datetime.now(UTC))
+        return issues
+
+    async def _fetch_issues(
+        self,
+        path: str | Path,
+        assigned_to_me: bool,
+        authored_by_me: bool,
+        limit: int,
+    ) -> list[GitHubIssue]:
+        """Fetch issues from GitHub API."""
+        json_fields = (
+            "number,title,state,url,createdAt,updatedAt,author,assignees,labels"
+        )
+        issues: list[GitHubIssue] = []
+        seen_numbers: set[int] = set()
+
+        if assigned_to_me:
+            code, stdout, _ = await self._run_gh(
+                "issue",
+                "list",
+                "--assignee",
+                "@me",
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                json_fields,
+                cwd=path,
+            )
+            if code == 0 and stdout:
+                for item in json.loads(stdout):
+                    if item["number"] not in seen_numbers:
+                        issues.append(self._parse_issue(item))
+                        seen_numbers.add(item["number"])
+
+        if authored_by_me:
+            code, stdout, _ = await self._run_gh(
+                "issue",
+                "list",
+                "--author",
+                "@me",
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                json_fields,
+                cwd=path,
+            )
+            if code == 0 and stdout:
+                for item in json.loads(stdout):
+                    if item["number"] not in seen_numbers:
+                        issues.append(self._parse_issue(item))
+                        seen_numbers.add(item["number"])
+
+        issues.sort(key=lambda i: i.updated_at, reverse=True)
+        return issues[:limit]
+
+    def _parse_issue(self, data: dict[str, object]) -> GitHubIssue:
+        """Parse JSON response into GitHubIssue model."""
+        author_data = data.get("author") or {}
+        author_login = (
+            author_data.get("login", "unknown")
+            if isinstance(author_data, dict)
+            else "unknown"
+        )
+
+        assignees_data = data.get("assignees", [])
+        assignees = []
+        if isinstance(assignees_data, list):
+            for a in assignees_data:
+                if isinstance(a, dict) and "login" in a:
+                    assignees.append(GitHubUser(login=str(a["login"])))
+
+        labels_data = data.get("labels", [])
+        labels = []
+        if isinstance(labels_data, list):
+            for lbl in labels_data:
+                if isinstance(lbl, dict) and "name" in lbl:
+                    labels.append(
+                        GitHubLabel(
+                            name=str(lbl["name"]), color=str(lbl.get("color", ""))
+                        )
+                    )
+
+        created_at_str = str(data.get("createdAt", ""))
+        updated_at_str = str(data.get("updatedAt", ""))
+
+        number_val = data.get("number", 0)
+        number = int(number_val) if isinstance(number_val, (int, str)) else 0
+
+        return GitHubIssue(
+            number=number,
+            title=str(data.get("title", "")),
+            state=str(data.get("state", "")),
+            url=str(data.get("url", "")),
+            created_at=datetime.fromisoformat(created_at_str.replace("Z", "+00:00")),
+            updated_at=datetime.fromisoformat(updated_at_str.replace("Z", "+00:00")),
+            author=GitHubUser(login=str(author_login)),
+            assignees=assignees,
+            labels=labels,
+        )
+
+    def invalidate_cache(self, repo_key: str | None = None) -> None:
+        """Invalidate cache for a specific repo or all repos."""
+        if repo_key:
+            self._cache.pop(repo_key, None)
+        else:
+            self._cache.clear()
+
+
+def get_github_service() -> GitHubService:
+    """Get the singleton GitHubService instance."""
+    return GitHubService()

--- a/forestui/theme.py
+++ b/forestui/theme.py
@@ -561,4 +561,124 @@ Container {
     color: $text-muted;
     padding: 0 1;
 }
+
+/* Sidebar Header Box */
+#sidebar-header-box {
+    width: 100%;
+    height: 4;
+    background: $bg-elevated;
+    border-bottom: solid $border;
+    align: center middle;
+    padding: 0;
+}
+
+#sidebar-title {
+    text-align: center;
+    width: 100%;
+    color: $accent;
+    text-style: bold;
+}
+
+#gh-status {
+    text-align: center;
+    width: 100%;
+    color: $text-muted;
+}
+
+.gh-status-ok {
+    color: $success;
+}
+
+.gh-status-warn {
+    color: $warning;
+}
+
+.gh-status-error {
+    color: $text-muted;
+}
+
+/* Async-loaded sections */
+#issues-container {
+    margin-top: 1;
+}
+
+#sessions-container {
+    margin-top: 1;
+}
+
+/* Section header with refresh button */
+.section-header-row {
+    height: auto;
+    width: auto;
+}
+
+.section-header-row .section-header {
+    width: auto;
+    margin: 0;
+}
+
+.refresh-btn {
+    min-width: 3;
+    width: 3;
+    height: 1;
+    padding: 0;
+    margin: 0;
+    border: none;
+    background: transparent;
+    color: $text-muted;
+    text-style: none;
+}
+
+.refresh-btn:focus {
+    color: $text-muted;
+    background: transparent;
+    border: none;
+    text-style: none;
+}
+
+.refresh-btn:hover {
+    color: $accent;
+    background: transparent;
+    border: none;
+}
+
+.refresh-btn:focus:hover {
+    color: $accent;
+    background: transparent;
+    border: none;
+}
+
+/* Issue List */
+.issue-row {
+    height: auto;
+    margin: 0 2 1 0;
+    padding: 1;
+    background: $bg-elevated;
+    border: solid $border;
+}
+
+.issue-row:hover {
+    background: $bg-hover;
+}
+
+.issue-info {
+    width: 1fr;
+}
+
+.issue-title {
+    color: $text-primary;
+}
+
+.issue-meta {
+    color: $text-muted;
+}
+
+.issue-btn {
+    min-width: 12;
+    margin-left: 1;
+}
+
+.issue-title-preview {
+    margin-bottom: 1;
+}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.6.0"
+version = "0.7.0"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary

Adds GitHub CLI (`gh`) integration to forestui, enabling seamless issue-to-worktree workflow.

### Features
- **GitHub issues panel** - Shows open issues assigned to or authored by the user in the repository detail view
- **Create WT from issue** - One-click worktree creation with pre-filled name and branch from issue (e.g., `42-fix-login-bug`)
- **gh CLI status indicator** - Sidebar header shows auth status with username: `gh cli: ok (flipbit03)`
- **Manual refresh button** - Spinner animation while refreshing, disabled during load
- **Pull before create** - Optional checkbox (default: on) to pull repo before creating worktree
- **Dev mode naming** - Running via `uv run forestui` names the window `forestui-dev-HHMM` for easy identification

### Technical improvements
- Background/async loading for issues and sessions (non-blocking UI startup)
- 5-minute auto-refresh for issues with in-memory caching
- Added async/reactive UI patterns to CLAUDE.md guidelines

## Test plan
- [ ] Run `forestui` with a GitHub-connected repo
- [ ] Verify `gh cli: ok (username)` shows in sidebar header
- [ ] Verify "MY OPEN GITHUB ISSUES" section appears with issues
- [ ] Click refresh button - verify spinner animation
- [ ] Click "Create WT" on an issue - verify modal pre-fills correctly
- [ ] Create worktree with "Pull repo before creating" checked
- [ ] Test with `gh auth logout` - status should show `unauth'd`
- [ ] Run `uv run forestui` - window should be named `forestui-dev-HHMM`