### PR TITLE
Remove dead COLORS dict from theme.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,12 @@ Version is defined in **both** `forestui/__init__.py` and `pyproject.toml`:
 __version__ = "0.1.0"
 ```
 
-**IMPORTANT:** Every commit to `main` must include a version bump in both files. This is required for `--self-update` to work correctly - it compares the local version against the remote to detect updates. If you forget to bump the version, users won't see the update.
+**IMPORTANT:** The `main` branch represents the release. Every feature, fix, or change merged to `main` **must** include a version bump in both files:
+- **Patch** (0.0.X): Bug fixes, dead code removal, minor cleanup
+- **Minor** (0.X.0): New features, enhancements
+- **Major** (X.0.0): Breaking changes
+
+This is required for `--self-update` to work correctly - it compares the local version against the remote to detect updates. If you forget to bump the version, users won't see the update.
 
 ### Workflow: Test Before Commit
 

--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,3 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/forestui/theme.py
+++ b/forestui/theme.py
@@ -1,37 +1,5 @@
 """Theme and styling for forestui."""
 
-# Forest Green Color Palette
-COLORS = {
-    # Accent colors (Forest Green)
-    "accent": "#2D6A4F",
-    "accent_light": "#52B788",
-    "accent_soft": "#D8F3DC",
-    "accent_dark": "#1B4332",
-    # Warm amber secondary
-    "accent_warm": "#B68D40",
-    "accent_warm_light": "#D4A855",
-    # Backgrounds
-    "bg": "#1C1C1E",
-    "bg_elevated": "#2C2C2E",
-    "bg_hover": "#3A3A3C",
-    "bg_selected": "#48484A",
-    "bg_subtle": "#252527",
-    # Borders
-    "border": "#3D3D3F",
-    "border_subtle": "#323234",
-    "border_focus": "#52B788",
-    # Text
-    "text_primary": "#F5F5F5",
-    "text_secondary": "#A8A8A8",
-    "text_muted": "#7A7A7A",
-    "text_tertiary": "#5A5A5A",
-    # Semantic
-    "destructive": "#FF6B6B",
-    "destructive_dark": "#C1292E",
-    "warning": "#FFB347",
-    "success": "#52B788",
-}
-
 # CSS styles for Textual
 APP_CSS = """
 $accent: #52B788;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "forestui"
-version = "0.6.0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Remove unused `COLORS` Python dict from `theme.py` (was defined but never imported)
- Colors remain properly defined as CSS variables in `APP_CSS`
- Document version bump policy in `CLAUDE.md`: since `main` = release, every change must bump version

## Test plan
- [x] `make check` passes (lint + typecheck)
- [x] App still renders with correct colors

Fixes #3