### PR TITLE
Replace custom relative_time with humanize.naturaltime()

### DIFF
--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,3 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,3 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/forestui/models.py
+++ b/forestui/models.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Self
 from uuid import UUID, uuid4
 
+import humanize
 from pydantic import BaseModel, Field
 
 
@@ -74,24 +75,7 @@ class ClaudeSession(BaseModel):
     @property
     def relative_time(self) -> str:
         """Get a human-readable relative time string."""
-        now = datetime.now(UTC)
-        diff = now - self.last_timestamp
-        seconds = diff.total_seconds()
-
-        if seconds < 60:
-            return "just now"
-        elif seconds < 3600:
-            mins = int(seconds / 60)
-            return f"{mins}m ago"
-        elif seconds < 86400:
-            hours = int(seconds / 3600)
-            return f"{hours}h ago"
-        elif seconds < 604800:
-            days = int(seconds / 86400)
-            return f"{days}d ago"
-        else:
-            weeks = int(seconds / 604800)
-            return f"{weeks}w ago"
+        return humanize.naturaltime(self.last_timestamp)
 
     @property
     def primary_branch(self) -> str | None:
@@ -165,16 +149,4 @@ class GitHubIssue(BaseModel):
     @property
     def relative_time(self) -> str:
         """Human-readable relative time since update."""
-        now = datetime.now(UTC)
-        diff = now - self.updated_at
-        seconds = diff.total_seconds()
-        if seconds < 60:
-            return "just now"
-        if seconds < 3600:
-            mins = int(seconds // 60)
-            return f"{mins}m ago"
-        if seconds < 86400:
-            hours = int(seconds // 3600)
-            return f"{hours}h ago"
-        days = int(seconds // 86400)
-        return f"{days}d ago"
+        return humanize.naturaltime(self.updated_at)

--- a/forestui/services/github.py
+++ b/forestui/services/github.py
@@ -181,7 +181,7 @@ class GitHubService:
                         issues.append(self._parse_issue(item))
                         seen_numbers.add(item["number"])
 
-        issues.sort(key=lambda i: i.updated_at, reverse=True)
+        issues.sort(key=lambda i: i.created_at, reverse=True)
         return issues[:limit]
 
     def _parse_issue(self, data: dict[str, object]) -> GitHubIssue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.7.3"
+version = "0.7.4"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary

- Removes duplicate custom time calculation logic in `ClaudeSession.relative_time` and `GitHubIssue.relative_time`
- Uses `humanize.naturaltime()` which is already a project dependency
- Sorts GitHub issues by creation date descending (newest first)
- Bumps version to 0.7.4

Closes #4

## Test plan

- [ ] Run `make check` to verify lint/typecheck pass
- [ ] Launch app and verify session timestamps display correctly
- [ ] Verify GitHub issues show newest first