### PR TITLE
Migrate self-update from git to PyPI (v0.9.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+permissions:
+  id-token: write
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Set version from GITHUB_REF
+        run: |
+          # GITHUB_REF is refs/tags/v1.2.3 - extract "1.2.3"
+          echo "GITHUB_REF: ${{ github.ref }}"
+          export VERSION=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,' -e 's/^v//')
+          echo "Setting version to $VERSION"
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+          echo "======================================"
+          echo "Version line in pyproject.toml:"
+          grep "^version" pyproject.toml
+          echo "======================================"
+
+      - name: Build wheels and source tarball
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,3 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -11,8 +11,6 @@ import click
 
 from forestui import __version__
 
-INSTALL_DIR = Path.home() / ".forestui-install"
-
 
 def get_window_name(dev_mode: bool = False) -> str:
     """Get the tmux window name based on dev mode flag."""

--- a/install.sh
+++ b/install.sh
@@ -2,22 +2,13 @@
 #
 # forestui installer
 #
-# This script installs forestui by:
-#   1. Checking for required dependencies (uv, tmux, git)
-#   2. Cloning the repository to ~/.forestui-install
-#   3. Installing via uv tool install
+# Installs forestui from PyPI using uv.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/flipbit03/forestui/main/install.sh | bash
 #
-# Or clone and run locally:
-#   ./install.sh
-#
 
 set -e
-
-REPO_URL="https://github.com/flipbit03/forestui.git"
-INSTALL_DIR="$HOME/.forestui-install"
 
 # Colors for output
 RED='\033[0;31m'
@@ -38,32 +29,14 @@ error() {
     exit 1
 }
 
-# Check for required commands
 check_command() {
-    if ! command -v "$1" &> /dev/null; then
-        return 1
-    fi
-    return 0
+    command -v "$1" &> /dev/null
 }
 
 info "forestui installer"
 echo ""
 
-# Check for git
-if ! check_command git; then
-    error "git is not installed. Please install git first."
-fi
-
-# Check for uv
-if ! check_command uv; then
-    error "uv is not installed. Please install uv first:
-
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-
-    Or visit: https://docs.astral.sh/uv/getting-started/installation/"
-fi
-
-# Check for tmux
+# Check for tmux (required dependency)
 if ! check_command tmux; then
     error "tmux is not installed. Please install tmux first:
 
@@ -72,32 +45,32 @@ if ! check_command tmux; then
     Fedora: sudo dnf install tmux"
 fi
 
-info "All dependencies found: git, uv, tmux"
+# Install uv if not present
+if ! check_command uv; then
+    info "Installing uv (Python package manager)..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Clone or update repository
-if [ -d "$INSTALL_DIR" ]; then
-    info "Updating existing installation at $INSTALL_DIR"
-    cd "$INSTALL_DIR"
-    git fetch origin main
-    git reset --hard origin/main
-else
-    info "Cloning repository to $INSTALL_DIR"
-    git clone "$REPO_URL" "$INSTALL_DIR"
-    cd "$INSTALL_DIR"
+    # Add to PATH for this session
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! check_command uv; then
+        error "Failed to install uv. Please install manually: https://docs.astral.sh/uv/"
+    fi
+    info "uv installed successfully"
 fi
 
-# Install with uv
-info "Installing forestui with uv tool install..."
-uv tool install . --force
+# Install forestui from PyPI
+info "Installing forestui from PyPI..."
+if uv tool install forestui; then
+    echo ""
+    info "Installation complete!"
+else
+    error "Failed to install forestui from PyPI"
+fi
 
-# "forestui" is now available in your $PATH
-
-echo ""
-info "Installation complete!"
 echo ""
 echo "  Run 'forestui' to start the application."
 echo "  Run 'forestui --help' for usage information."
-echo "  Run 'forestui --self-update' to update to the latest version."
 echo ""
 
 # Check if uv tools are in PATH
@@ -109,4 +82,13 @@ if ! check_command forestui; then
     echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
     echo ""
     echo "  Then restart your shell or run: source ~/.bashrc"
+fi
+
+# Notify about old installation directory
+OLD_INSTALL_DIR="$HOME/.forestui-install"
+if [ -d "$OLD_INSTALL_DIR" ]; then
+    echo ""
+    info "Note: Found old git-based installation at $OLD_INSTALL_DIR"
+    echo "  This directory is no longer needed. You can remove it with:"
+    echo "    rm -rf $OLD_INSTALL_DIR"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.8.0"
+version = "0.9.0"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "forestui"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

This is the **bridge release** (Step 1 of 2) that transitions existing users from git-based updates to PyPI-based updates.

- Add GitHub Actions workflow for PyPI publishing via OIDC trusted publishing
- Replace git-based `_auto_update()` with PyPI-based version using `uv tool install forestui --force --upgrade`
- Remove `INSTALL_DIR` constant (no longer needed)
- Rewrite `install.sh` to install from PyPI instead of git clone
- Bump version to 0.9.0

Closes #12

## How It Works

Existing users (v0.7.x, v0.8.x) will pull this release via the old git mechanism. Once they have v0.9.0, all future updates come from PyPI.

## Post-Merge Steps

1. Create and push tag: `git tag v0.9.0 && git push origin v0.9.0`
2. Create GitHub Release from the tag
3. Verify PyPI publication: `uv pip index versions forestui`

## Test Plan

- [x] `make check` passes (lint + typecheck)
- [x] App starts and runs correctly
- [x] Auto-update shows "checking for updates..." then clears (expected - not on PyPI yet)