### PR TITLE
Switch to dynamic versioning via git tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,31 +160,23 @@ Currently no test suite. When adding tests:
 
 ## Versioning
 
-Version is defined in **both** `forestui/__init__.py` and `pyproject.toml`:
-```python
-__version__ = "0.1.0"
+Version is `0.0.0` in source code. Actual versions are derived from git tags at release time.
+
+### Development
+
+1. Create a branch, make changes
+2. Run `make check` and test locally
+3. Open a PR and merge to `main`
+
+Running from source (`uv run forestui`) shows version `0.0.0` and auto-enables dev mode.
+
+### Releasing
+
+```bash
+gh release create v0.9.1 --generate-notes
 ```
 
-**IMPORTANT:** The `main` branch represents the release. Every feature, fix, or change merged to `main` **must** include a version bump in both files:
-- **Patch** (0.0.X): Bug fixes, dead code removal, minor cleanup
-- **Minor** (0.X.0): New features, enhancements
-- **Major** (X.0.0): Breaking changes
-
-This is required for `--self-update` to work correctly - it compares the local version against the remote to detect updates. If you forget to bump the version, users won't see the update.
-
-### Workflow: Test Before Commit
-
-**Do NOT bump the version, commit, or push until the user has tested and approved the changes.**
-
-Every commit to `main` with a bumped version is an actual release that will propagate to all users via `--self-update`. The workflow should be:
-
-1. Make code changes
-2. Run `make check` to verify lint/typecheck pass (do this BEFORE bumping version - if linter reformats code, you don't want to bump twice)
-3. **Ask the user to test the changes** before proceeding
-4. Bump version in both `forestui/__init__.py` and `pyproject.toml`
-5. Commit and push
-
-This keeps a human in the loop for quality control before releasing.
+This triggers the publish workflow which builds and publishes to PyPI.
 
 ## Git Commits
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,32 @@ forestui brings the power of Git worktree management to the terminal with a beau
 - Python 3.14+
 - tmux
 - uv (for installation)
+- [gh](https://cli.github.com/) (optional, for GitHub integration)
 
 ## Installing
 
+### Quick Install (recommended)
+
+Installs [uv](https://github.com/astral-sh/uv) automatically if not present. No Python installation required.
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/flipbit03/forestui/main/install.sh | bash
+```
+
+### Install via uv
+
+If you already have [uv](https://github.com/astral-sh/uv) installed:
+
+```bash
+uv tool install forestui
+```
+
+### Updating
+
+forestui auto-updates on startup. To manually update:
+
+```bash
+uv tool upgrade forestui
 ```
 
 ## Usage
@@ -35,9 +56,6 @@ forestui
 
 # Start with a custom forest directory
 forestui ~/my-projects
-
-# Update to latest version
-forestui --self-update
 
 # Show help
 forestui --help

--- a/forestui/__init__.py
+++ b/forestui/__init__.py
@@ -1,3 +1,9 @@
 """forestui - A Terminal UI for managing Git worktrees."""
 
-__version__ = "0.9.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("forestui")
+except PackageNotFoundError:
+    # Package not installed (running from source without install)
+    __version__ = "0.0.0"

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -147,6 +147,9 @@ def main(
 
     FOREST_PATH: Optional path to forest directory (default: ~/forest)
     """
+    # Auto-enable dev mode when running from source (version 0.0.0)
+    dev_mode = dev_mode or __version__ == "0.0.0"
+
     ensure_tmux(forest_path, debug_mode, no_self_update, dev_mode)
 
     if debug_mode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestui"
-version = "0.9.0"
+version = "0.0.0"
 description = "A Terminal UI for managing Git worktrees"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "forestui"
-version = "0.9.0"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Implements Step 2 of the PyPI migration (issue #13). After the bridge release (v0.9.0), this switches from hardcoded versions to dynamic versioning:

- `pyproject.toml` version is now `0.0.0` (placeholder, replaced at build time by publish workflow)
- `__init__.py` uses `importlib.metadata.version("forestui")` to read installed package version
- Auto-enables dev mode (timestamped tmux windows) when running from source

## Changes

- **forestui/__init__.py**: Dynamic version via `importlib.metadata`
- **pyproject.toml**: Version set to `0.0.0`
- **forestui/cli.py**: Auto-enable dev mode when version is `0.0.0`
- **CLAUDE.md**: Updated versioning docs with tag-based release workflow
- **README.md**: Improved install section, removed obsolete `--self-update` reference

## Release workflow after this

```bash
gh release create v0.9.1 --generate-notes
```

That's it. The publish workflow handles version injection and PyPI publishing.

Closes #13