### PR TITLE
Add base branch selection and worktree origin tracking

### DIFF
--- a/forestui/components/worktree_detail.py
+++ b/forestui/components/worktree_detail.py
@@ -106,6 +106,12 @@ class WorktreeDetail(Widget):
                     f"Branch:     {self._worktree.branch}",
                     classes="label-accent",
                 )
+                # Base branch info (if available)
+                if self._worktree.base_branch:
+                    base_text = f"Based on:   {self._worktree.base_branch}"
+                    if self._worktree.created_from_ref:
+                        base_text += f" ({self._worktree.created_from_ref})"
+                    yield Label(base_text, classes="label-muted")
                 # Commit info
                 if self._commit_hash:
                     relative_time = (

--- a/forestui/models.py
+++ b/forestui/models.py
@@ -69,6 +69,10 @@ class Worktree(BaseModel):
     sort_order: int | None = None
     last_modified: datetime = Field(default_factory=lambda: datetime.now(UTC))
     custom_claude_command: str | None = None
+    # Branch this worktree was created from (e.g., "origin/main")
+    base_branch: str | None = None
+    # Git commit ref when the worktree was created
+    created_from_ref: str | None = None
 
     @field_validator("custom_claude_command")
     @classmethod

--- a/forestui/theme.py
+++ b/forestui/theme.py
@@ -246,8 +246,8 @@ ModalScreen {
 }
 
 .modal-container {
-    width: 60;
-    max-width: 80%;
+    width: 80;
+    max-width: 90%;
     height: auto;
     max-height: 90%;
     background: $bg-elevated;
@@ -519,6 +519,21 @@ Container {
 
 .action-row Button {
     margin-right: 1;
+}
+
+/* Base branch row in modal */
+.base-branch-row {
+    height: 3;
+    width: 100%;
+}
+
+.base-branch-row Input {
+    width: 1fr;
+}
+
+.base-branch-row Button {
+    min-width: 10;
+    margin-left: 1;
 }
 
 /* Branch tag */


### PR DESCRIPTION
## Summary

Adds base branch selection when creating worktrees, and tracks worktree origin information.

### New Features

- **Base branch selector with autocomplete** in "Create Worktree from Issue" modal
  - Input field with autocomplete suggestions (use → to accept)
  - Defaults to `origin/<current-branch>` if available
  - Fetch button with spinning animation to refresh remote branches
  - Create button disabled when base branch is invalid

- **Autocomplete for existing branch selection** in "Add Worktree" modal
  - Replaced Select dropdown with Input + autocomplete
  - Create button disabled when branch doesn't exist
  - Validates branch exists before allowing creation

- **Worktree origin tracking**
  - New `base_branch` field - the branch the worktree was created from
  - New `created_from_ref` field - the git commit ref at creation time
  - Displayed as "Based on: origin/main (abc1234)" in worktree detail view

### Improvements

- `list_branches()` now dynamically detects and includes all remotes (not just origin/upstream)
- Filters out bare remote names (e.g., "origin") from branch lists
- Wider modal container (60 → 80 chars) for better readability
- Error messages clear when user types
- Better error messages (e.g., "Branch 'xyz' does not exist")

### Bug Fixes

- **Fixed detached HEAD when checking out remote branches** - When selecting a remote branch like `origin/feature-branch` in "existing branch" mode, creates a local tracking branch instead of detached HEAD
- **Correct tracking for existing vs new branches**:
  - Existing remote branch → creates local tracking branch (git pull/push work correctly)
  - New branch from remote base → no tracking (user will `git push -u` to create new remote branch)

### UI/UX

- Fetch button shows spinning `|/-\` animation while fetching
- Create buttons are disabled when branch fields contain invalid refs
- Autocomplete works with right arrow key (→) to accept suggestions

## Test plan

- [x] Create worktree from GitHub issue (new branch)
  - [x] Verify base branch selector shows with autocomplete
  - [x] Verify Fetch button refreshes branches with spinner animation
  - [x] Verify Create button is disabled for invalid base branch
  - [ ] Verify new worktree shows "Based on:" info in detail view
  - [x] Verify `git push -u origin <branch>` works to create new remote branch
- [x] Add worktree with existing remote branch
  - [x] Verify autocomplete works for branch selection
  - [x] Verify Create button is disabled for non-existent branch
  - [x] Verify "origin" alone is not suggested/allowed
  - [x] Verify NOT detached HEAD - local tracking branch created
  - [x] Verify `git pull` and `git push` work correctly
- [x] Add worktree with new branch (from local base)
  - [x] Verify worktree tracks base branch info in UI
- [x] Verify existing worktrees still display correctly (without base branch info)