### PR TITLE
Use grouped tmux sessions for independent window navigation

### DIFF
--- a/.claude/skills/test-forestui/SKILL.md
+++ b/.claude/skills/test-forestui/SKILL.md
@@ -60,12 +60,18 @@ tu run --name fui-b --env TMUX_TMPDIR=$FUI_TEST_DIR \
 
 ## How to see the screen
 
+**ALWAYS use PNG mode for screenshots.** Plain text loses colors, highlights, and
+styling — you can't tell which tmux window is active, what's selected, or see
+UI state like notifications. PNG gives you the real terminal with full color.
+
 ```bash
-tu screenshot --name fui        # full screen dump
-tu scrollback --name fui        # if content scrolled off
+tu screenshot --name fui --png -o /tmp/fui-shot.png   # then Read the file to see it
+tu scrollback --name fui                               # if content scrolled off
 ```
 
-The status bar is the last line. Parse it for session name, window list, etc.
+Use the Read tool on the PNG to visually inspect it. The status bar is at the
+bottom — look for the orange-highlighted active window to know which window
+each session is viewing.
 
 ## How to interact
 

--- a/.claude/skills/test-forestui/SKILL.md
+++ b/.claude/skills/test-forestui/SKILL.md
@@ -34,7 +34,10 @@ If no `.tmux.conf`: defaults are prefix `Ctrl+B`, next `Ctrl+B n`, prev `Ctrl+B 
 
 ## How to launch forestui
 
-forestui auto-execs into tmux. Isolate from the user's real session:
+**NEVER run `uv run forestui` or any tmux command without `TMUX_TMPDIR` isolation.**
+The user is likely running their own tmux/forestui session right now. If you
+connect to the default tmux server you will interfere with their live session —
+creating windows, switching their active view, or corrupting their session state.
 
 ```bash
 FUI_TEST_DIR=$(mktemp -d)

--- a/.claude/skills/test-forestui/SKILL.md
+++ b/.claude/skills/test-forestui/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: test-forestui
+description: Use tu to visually drive and test forestui in headless terminals. Invoke when developing forestui features, debugging UI issues, or verifying changes — lets you see and interact with the running app yourself.
+allowed-tools: Bash, Read
+argument-hint: "[what to test or verify]"
+---
+
+# Self-drive forestui with `tu`
+
+You can launch, see, and interact with forestui in headless virtual terminals
+using `tu` (terminal-use). This gives you the ability to visually verify your
+own code changes without the user needing to test manually.
+
+Use this whenever you're developing forestui and want to confirm your changes
+work. Design your own test approach based on what you changed — there is no
+fixed test suite. You are the tester.
+
+## FIRST: bootstrap context
+
+Before doing ANYTHING else, run these two commands and read their output.
+Do NOT skip. Do NOT proceed until both are in context.
+
+```bash
+tu usage
+```
+```bash
+cat ~/.tmux.conf 2>/dev/null || echo "NO_TMUX_CONF"
+```
+
+From `tu usage`: learn all commands, key syntax, wait conditions.
+From `.tmux.conf`: learn the user's tmux prefix and all keybindings.
+Translate tmux bind syntax to `tu press` key names yourself from these two sources.
+If no `.tmux.conf`: defaults are prefix `Ctrl+B`, next `Ctrl+B n`, prev `Ctrl+B p`.
+
+## How to launch forestui
+
+forestui auto-execs into tmux. Isolate from the user's real session:
+
+```bash
+FUI_TEST_DIR=$(mktemp -d)
+
+tu run --name fui --env TMUX_TMPDIR=$FUI_TEST_DIR \
+  --cwd <project-root> -- env -u TMUX uv run forestui
+
+tu wait --name fui --text "forestui" --timeout 15000
+```
+
+Need multiple terminals (e.g., testing grouped sessions)? Use the same
+`TMUX_TMPDIR` so they share the same isolated tmux server:
+
+```bash
+tu run --name fui-a --env TMUX_TMPDIR=$FUI_TEST_DIR \
+  --cwd <project-root> -- env -u TMUX uv run forestui
+tu run --name fui-b --env TMUX_TMPDIR=$FUI_TEST_DIR \
+  --cwd <project-root> -- env -u TMUX uv run forestui
+```
+
+## How to see the screen
+
+```bash
+tu screenshot --name fui        # full screen dump
+tu scrollback --name fui        # if content scrolled off
+```
+
+The status bar is the last line. Parse it for session name, window list, etc.
+
+## How to interact
+
+### forestui hotkeys (direct, no tmux prefix)
+
+`e` editor, `t` terminal, `o` files (mc), `n` claude, `y` yolo claude,
+`a` add repo, `w` add worktree, `q` quit, `h` archive, `d` delete,
+`Up`/`Down` navigate sidebar, `Enter` select.
+
+### tmux navigation
+
+Use the bindings from `.tmux.conf`. Translate to `tu press` yourself.
+
+### Text input
+
+```bash
+tu type --name fui "text"       # literal text
+tu press --name fui Enter       # keystrokes
+tu paste --name fui "text"      # bracketed paste
+```
+
+## How to verify
+
+Screenshot, read, assert. Design checks based on what you changed:
+
+- **UI change?** Screenshot and check the relevant region.
+- **New window?** Check the status bar for the expected window name.
+- **Multi-terminal behavior?** Launch two instances, act in one, screenshot both.
+- **Key binding?** Press it, screenshot, confirm the expected result.
+- **Error case?** Trigger it, screenshot, check for error message or correct state.
+
+Use `tu wait --text "pattern"` when you know what to expect.
+Use `sleep 1` after tmux window changes.
+
+## Cleanup
+
+ALWAYS clean up when done:
+
+```bash
+tu kill --name fui 2>/dev/null
+tu kill --name fui-a 2>/dev/null
+tu kill --name fui-b 2>/dev/null
+rm -rf $FUI_TEST_DIR
+```
+
+## Tips
+
+- `tu wait --text "pattern" --timeout 10000` is better than `sleep`
+- `tu status --name fui` to check if a session is alive
+- `tu list` to see all active sessions
+- If something looks wrong, screenshot FIRST before retrying
+- The active tmux window isn't visually distinct in plain text screenshots,
+  but the first line of content tells you what's displayed
+
+## Multi-terminal testing
+
+forestui uses tmux grouped sessions so multiple terminals can share the same
+windows but navigate independently. To test this kind of behavior — or any
+scenario where two users/terminals interact with the same forestui session —
+launch multiple `tu` instances sharing the same `TMUX_TMPDIR`:
+
+```bash
+tu run --name fui-a --env TMUX_TMPDIR=$FUI_TEST_DIR \
+  --cwd <project-root> -- env -u TMUX uv run forestui
+tu run --name fui-b --env TMUX_TMPDIR=$FUI_TEST_DIR \
+  --cwd <project-root> -- env -u TMUX uv run forestui
+```
+
+Because they share `TMUX_TMPDIR`, they connect to the same tmux server.
+The first creates the original session; subsequent ones join it as grouped
+sessions — exactly like a user opening forestui from multiple terminals.
+
+This lets you:
+- Act in one session (`tu press --name fui-b t`) and screenshot the other
+  (`tu screenshot --name fui-a`) to confirm it wasn't affected
+- Verify that window creation from either terminal targets the correct session
+- Check that both status bars show consistent info (same session name, same
+  window list) despite being different tmux sessions internally
+- Test any feature where "what happens in terminal A vs terminal B" matters
+
+You can launch as many parallel sessions as needed (fui-a, fui-b, fui-c, ...).
+Clean up ALL of them when done.

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -111,7 +111,19 @@ def ensure_tmux(
                 ],
             )
 
-        os.execvp("tmux", ["tmux", "attach-session", "-t", session_name])
+        os.execvp(
+            "tmux",
+            [
+                "tmux",
+                "new-session",
+                "-t",
+                session_name,
+                ";",
+                "set-option",
+                "destroy-unattached",
+                "on",
+            ],
+        )
     else:
         # No session: create new one with forestui as initial command
         os.execvp("tmux", ["tmux", "new-session", "-s", session_name, forestui_cmd])

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import sys
 from pathlib import Path
@@ -78,7 +79,7 @@ def ensure_tmux(
     if dev_mode:
         forestui_cmd += " --dev"
     if forest_path:
-        forestui_cmd += f" {forest_path}"
+        forestui_cmd += f" {shlex.quote(forest_path)}"
 
     # Check if session already exists
     import subprocess
@@ -90,12 +91,13 @@ def ensure_tmux(
     session_exists = result.returncode == 0
 
     if session_exists:
-        # Session exists: check if forestui window is already running
-        result = subprocess.run(
-            ["tmux", "select-window", "-t", f"{session_name}:forestui"],
+        # Check if forestui window exists (read-only, no side effects)
+        list_result = subprocess.run(
+            ["tmux", "list-windows", "-t", session_name, "-F", "#{window_name}"],
             capture_output=True,
+            text=True,
         )
-        forestui_window_exists = result.returncode == 0
+        forestui_window_exists = "forestui" in (list_result.stdout or "").splitlines()
 
         if not forestui_window_exists:
             # forestui was killed but session remains - create new window
@@ -114,13 +116,18 @@ def ensure_tmux(
         # Create a grouped session for independent window navigation.
         # Each terminal gets its own session linked to the same window group,
         # so switching windows in one terminal doesn't affect the other.
-        # We use a hook to set destroy-unattached AFTER the client attaches,
-        # because setting it on a detached session destroys it immediately.
         grouped_name = f"{session_name}-{os.getpid()}"
-        subprocess.run(
+        grouped_result = subprocess.run(
             ["tmux", "new-session", "-d", "-s", grouped_name, "-t", session_name],
             capture_output=True,
         )
+        if grouped_result.returncode != 0:
+            # Grouped session creation failed, fall back to direct attach
+            os.execvp("tmux", ["tmux", "attach-session", "-t", session_name])
+
+        # Use a hook to set destroy-unattached AFTER the client attaches,
+        # because setting it on a detached session destroys it immediately.
+        # keep-last prevents the last session in the group from being destroyed.
         subprocess.run(
             [
                 "tmux",
@@ -128,28 +135,20 @@ def ensure_tmux(
                 "-t",
                 grouped_name,
                 "client-attached",
-                "set-option destroy-unattached on",
+                "set-option destroy-unattached keep-last",
             ],
             capture_output=True,
         )
         # Override status-left so the grouped session shows the base session
-        # name instead of the PID-suffixed internal name.
+        # name instead of the PID-suffixed internal name. Uses -gv to get
+        # just the value without the option name prefix or quoting.
         status_result = subprocess.run(
-            ["tmux", "show-options", "-g", "status-left"],
+            ["tmux", "show-options", "-gv", "status-left"],
             capture_output=True,
             text=True,
         )
         if status_result.returncode == 0 and status_result.stdout.strip():
-            # Replace #S (session name variable) with the literal base name
-            status_left = status_result.stdout.strip().removeprefix("status-left ")
-            # Strip outer quotes if present
-            if (
-                len(status_left) >= 2
-                and status_left[0] == '"'
-                and status_left[-1] == '"'
-            ):
-                status_left = status_left[1:-1]
-            status_left = status_left.replace("#S", session_name)
+            status_left = status_result.stdout.strip().replace("#S", session_name)
             subprocess.run(
                 ["tmux", "set-option", "-t", grouped_name, "status-left", status_left],
                 capture_output=True,

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -85,7 +85,7 @@ def ensure_tmux(
     import subprocess
 
     result = subprocess.run(
-        ["tmux", "has-session", "-t", session_name],
+        ["tmux", "has-session", "-t", f"={session_name}"],
         capture_output=True,
     )
     session_exists = result.returncode == 0
@@ -93,7 +93,7 @@ def ensure_tmux(
     if session_exists:
         # Check if forestui window exists (read-only, no side effects)
         list_result = subprocess.run(
-            ["tmux", "list-windows", "-t", session_name, "-F", "#{window_name}"],
+            ["tmux", "list-windows", "-t", f"={session_name}", "-F", "#{window_name}"],
             capture_output=True,
             text=True,
         )
@@ -110,7 +110,7 @@ def ensure_tmux(
                     "tmux",
                     "new-window",
                     "-t",
-                    session_name,
+                    f"={session_name}",
                     "-n",
                     "forestui",
                     forestui_cmd,
@@ -122,7 +122,7 @@ def ensure_tmux(
         # so switching windows in one terminal doesn't affect the other.
         grouped_name = f"{session_name}-{os.getpid()}"
         grouped_result = subprocess.run(
-            ["tmux", "new-session", "-d", "-s", grouped_name, "-t", session_name],
+            ["tmux", "new-session", "-d", "-s", grouped_name, "-t", f"={session_name}"],
             capture_output=True,
         )
         if grouped_result.returncode != 0:

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -97,7 +97,11 @@ def ensure_tmux(
             capture_output=True,
             text=True,
         )
-        forestui_window_exists = "forestui" in (list_result.stdout or "").splitlines()
+        window_names = (list_result.stdout or "").splitlines()
+        forestui_window_exists = any(
+            name == "forestui" or name.startswith("forestui-dev-")
+            for name in window_names
+        )
 
         if not forestui_window_exists:
             # forestui was killed but session remains - create new window

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -132,6 +132,28 @@ def ensure_tmux(
             ],
             capture_output=True,
         )
+        # Override status-left so the grouped session shows the base session
+        # name instead of the PID-suffixed internal name.
+        status_result = subprocess.run(
+            ["tmux", "show-options", "-g", "status-left"],
+            capture_output=True,
+            text=True,
+        )
+        if status_result.returncode == 0 and status_result.stdout.strip():
+            # Replace #S (session name variable) with the literal base name
+            status_left = status_result.stdout.strip().removeprefix("status-left ")
+            # Strip outer quotes if present
+            if (
+                len(status_left) >= 2
+                and status_left[0] == '"'
+                and status_left[-1] == '"'
+            ):
+                status_left = status_left[1:-1]
+            status_left = status_left.replace("#S", session_name)
+            subprocess.run(
+                ["tmux", "set-option", "-t", grouped_name, "status-left", status_left],
+                capture_output=True,
+            )
         os.execvp("tmux", ["tmux", "attach-session", "-t", grouped_name])
     else:
         # No session: create new one with forestui as initial command

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -114,13 +114,22 @@ def ensure_tmux(
         # Create a grouped session for independent window navigation.
         # Each terminal gets its own session linked to the same window group,
         # so switching windows in one terminal doesn't affect the other.
+        # We use a hook to set destroy-unattached AFTER the client attaches,
+        # because setting it on a detached session destroys it immediately.
         grouped_name = f"{session_name}-{os.getpid()}"
         subprocess.run(
             ["tmux", "new-session", "-d", "-s", grouped_name, "-t", session_name],
             capture_output=True,
         )
         subprocess.run(
-            ["tmux", "set-option", "-t", grouped_name, "destroy-unattached", "on"],
+            [
+                "tmux",
+                "set-hook",
+                "-t",
+                grouped_name,
+                "client-attached",
+                "set-option destroy-unattached on",
+            ],
             capture_output=True,
         )
         os.execvp("tmux", ["tmux", "attach-session", "-t", grouped_name])

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -111,19 +111,19 @@ def ensure_tmux(
                 ],
             )
 
-        os.execvp(
-            "tmux",
-            [
-                "tmux",
-                "new-session",
-                "-t",
-                session_name,
-                ";",
-                "set-option",
-                "destroy-unattached",
-                "on",
-            ],
+        # Create a grouped session for independent window navigation.
+        # Each terminal gets its own session linked to the same window group,
+        # so switching windows in one terminal doesn't affect the other.
+        grouped_name = f"{session_name}-{os.getpid()}"
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", grouped_name, "-t", session_name],
+            capture_output=True,
         )
+        subprocess.run(
+            ["tmux", "set-option", "-t", grouped_name, "destroy-unattached", "on"],
+            capture_output=True,
+        )
+        os.execvp("tmux", ["tmux", "attach-session", "-t", grouped_name])
     else:
         # No session: create new one with forestui as initial command
         os.execvp("tmux", ["tmux", "new-session", "-s", session_name, forestui_cmd])

--- a/forestui/cli.py
+++ b/forestui/cli.py
@@ -151,8 +151,9 @@ def ensure_tmux(
             capture_output=True,
             text=True,
         )
-        if status_result.returncode == 0 and status_result.stdout.strip():
-            status_left = status_result.stdout.strip().replace("#S", session_name)
+        if status_result.returncode == 0 and status_result.stdout.rstrip("\n"):
+            # Only strip the trailing newline, not spaces that are part of the template
+            status_left = status_result.stdout.rstrip("\n").replace("#S", session_name)
             subprocess.run(
                 ["tmux", "set-option", "-t", grouped_name, "status-left", status_left],
                 capture_output=True,

--- a/forestui/services/tmux.py
+++ b/forestui/services/tmux.py
@@ -60,19 +60,26 @@ class TmuxService:
             return None
         if self._session is None:
             try:
-                # Get session from TMUX environment variable
-                # Format: /socket/path,pid,window_index
-                tmux_env = os.environ.get("TMUX", "")
-                if tmux_env:
-                    # Find the attached session (session_attached is a count > 0)
+                # Use display-message to get the actual session we're running in.
+                # This is critical for grouped sessions where multiple sessions
+                # are attached but we need the one THIS process belongs to.
+                result = self.server.cmd("display-message", "-p", "#{session_id}")
+                current_id = result.stdout[0].strip() if result.stdout else ""
+                if current_id:
+                    for sess in self.server.sessions:
+                        if sess.session_id == current_id:
+                            self._session = sess
+                            break
+                # Fallback: find any attached session
+                if self._session is None:
                     for sess in self.server.sessions:
                         attached = sess.session_attached
                         if attached and int(attached) > 0:
                             self._session = sess
                             break
-                    # Fallback to first session if none found
-                    if self._session is None and self.server.sessions:
-                        self._session = self.server.sessions[0]
+                # Fallback to first session if none found
+                if self._session is None and self.server.sessions:
+                    self._session = self.server.sessions[0]
             except (LibTmuxException, ValueError, TypeError):
                 return None
         return self._session

--- a/forestui/services/tmux.py
+++ b/forestui/services/tmux.py
@@ -62,23 +62,34 @@ class TmuxService:
         if not self.is_inside_tmux or self.server is None:
             return None
         try:
-            # Find the most recently active client's session.
+            # Get our session group so we only consider clients attached to
+            # sessions in the same group — not unrelated tmux sessions.
+            group_result = self.server.cmd("display-message", "-p", "#{session_group}")
+            our_group = group_result.stdout[0].strip() if group_result.stdout else ""
+
+            # Find the most recently active client in our session group.
             # In grouped sessions, multiple clients are attached to different
             # sessions sharing the same windows. The user who just triggered
             # an action is the most recently active client.
             result = self.server.cmd(
-                "list-clients", "-F", "#{client_activity} #{session_id}"
+                "list-clients",
+                "-F",
+                "#{client_activity} #{session_id} #{session_group}",
             )
             if result.stdout:
                 best_id: str | None = None
                 best_time = -1
                 for line in result.stdout:
-                    parts = line.strip().split(" ", 1)
-                    if len(parts) == 2:
+                    parts = line.strip().split(" ", 2)
+                    if len(parts) == 3:
                         activity = int(parts[0])
+                        session_id = parts[1]
+                        group = parts[2]
+                        if our_group and group != our_group:
+                            continue
                         if activity > best_time:
                             best_time = activity
-                            best_id = parts[1]
+                            best_id = session_id
                 if best_id:
                     for sess in self.server.sessions:
                         if sess.session_id == best_id:

--- a/forestui/services/tmux.py
+++ b/forestui/services/tmux.py
@@ -29,7 +29,6 @@ class TmuxService:
 
     _instance: TmuxService | None = None
     _server: Server | None = None
-    _session: Session | None = None
 
     def __new__(cls) -> TmuxService:
         if cls._instance is None:
@@ -55,34 +54,46 @@ class TmuxService:
 
     @property
     def session(self) -> Session | None:
-        """Get the current tmux session."""
+        """Get the session of the most recently active tmux client.
+
+        Not cached because the active client can change between grouped
+        sessions — the user may be viewing forestui from any terminal.
+        """
         if not self.is_inside_tmux or self.server is None:
             return None
-        if self._session is None:
-            try:
-                # Use display-message to get the actual session we're running in.
-                # This is critical for grouped sessions where multiple sessions
-                # are attached but we need the one THIS process belongs to.
-                result = self.server.cmd("display-message", "-p", "#{session_id}")
-                current_id = result.stdout[0].strip() if result.stdout else ""
-                if current_id:
+        try:
+            # Find the most recently active client's session.
+            # In grouped sessions, multiple clients are attached to different
+            # sessions sharing the same windows. The user who just triggered
+            # an action is the most recently active client.
+            result = self.server.cmd(
+                "list-clients", "-F", "#{client_activity} #{session_id}"
+            )
+            if result.stdout:
+                best_id: str | None = None
+                best_time = -1
+                for line in result.stdout:
+                    parts = line.strip().split(" ", 1)
+                    if len(parts) == 2:
+                        activity = int(parts[0])
+                        if activity > best_time:
+                            best_time = activity
+                            best_id = parts[1]
+                if best_id:
                     for sess in self.server.sessions:
-                        if sess.session_id == current_id:
-                            self._session = sess
-                            break
-                # Fallback: find any attached session
-                if self._session is None:
-                    for sess in self.server.sessions:
-                        attached = sess.session_attached
-                        if attached and int(attached) > 0:
-                            self._session = sess
-                            break
-                # Fallback to first session if none found
-                if self._session is None and self.server.sessions:
-                    self._session = self.server.sessions[0]
-            except (LibTmuxException, ValueError, TypeError):
-                return None
-        return self._session
+                        if sess.session_id == best_id:
+                            return sess
+            # Fallback: first attached session
+            for sess in self.server.sessions:
+                attached = sess.session_attached
+                if attached and int(attached) > 0:
+                    return sess
+            # Fallback: first session
+            if self.server.sessions:
+                return self.server.sessions[0]
+        except (LibTmuxException, ValueError, TypeError):
+            return None
+        return None
 
     @property
     def current_window(self) -> Window | None:


### PR DESCRIPTION
## Summary

- Replace `tmux attach-session` with grouped sessions (`tmux new-session -t`) so each terminal can independently navigate tmux windows
- Each subsequent terminal creates a PID-named grouped session linked to the original, avoiding shared active-window cursors
- Use a `client-attached` hook to defer setting `destroy-unattached`, since setting it on a detached session destroys it immediately
- Grouped sessions auto-cleanup on disconnect; the original session persists as the anchor

Closes #20

## Test plan

- [x] Open `forestui` in terminal A — creates the original tmux session
- [x] Open `forestui` in terminal B — creates a grouped session (verify with `tmux list-sessions`)
- [x] Switch tmux windows in terminal B — terminal A stays on its current window
- [x] Open terminal C — also gets its own independent grouped session
- [x] Close terminal B — grouped session is destroyed, original and C persist
- [ ] Detach from terminal A — original session persists, can reattach