### PR TITLE
Add custom Claude buttons configurable in settings

### DIFF
--- a/forestui/app.py
+++ b/forestui/app.py
@@ -14,19 +14,19 @@ from textual.widgets import Footer, Header, Label
 
 from forestui import __version__
 from forestui.components.messages import (
-    ConfigureClaudeCommand,
+    ContinueClaudeCustomSession,
     ContinueClaudeSession,
     ContinueClaudeYoloSession,
     OpenInEditor,
     OpenInFileManager,
     OpenInTerminal,
+    StartClaudeCustomSession,
     StartClaudeSession,
     StartClaudeYoloSession,
 )
 from forestui.components.modals import (
     AddRepositoryModal,
     AddWorktreeModal,
-    ClaudeCommandModal,
     ConfirmDeleteModal,
     CreateWorktreeFromIssueModal,
     SettingsModal,
@@ -34,7 +34,12 @@ from forestui.components.modals import (
 from forestui.components.repository_detail import RepositoryDetail
 from forestui.components.sidebar import Sidebar
 from forestui.components.worktree_detail import WorktreeDetail
-from forestui.models import ClaudeCommandResult, GitHubIssue, Repository, Worktree
+from forestui.models import (
+    CustomClaudeButton,
+    GitHubIssue,
+    Repository,
+    Worktree,
+)
 from forestui.services.claude_session import get_claude_session_service
 from forestui.services.git import GitError, get_git_service
 from forestui.services.github import get_github_service
@@ -278,6 +283,7 @@ class ForestApp(App[None]):
                         commit_hash=commit_hash,
                         commit_time=commit_time,
                         has_remote=has_remote,
+                        custom_buttons=self._settings_service.settings.custom_buttons,
                     )
                 )
                 # Fetch sessions in background
@@ -314,6 +320,7 @@ class ForestApp(App[None]):
                     commit_hash=commit_hash,
                     commit_time=commit_time,
                     has_remote=has_remote,
+                    custom_buttons=self._settings_service.settings.custom_buttons,
                 )
                 await detail_pane.mount(detail)
                 # Start spinner and fetch sessions and issues in background
@@ -380,6 +387,16 @@ class ForestApp(App[None]):
         """Handle continue Claude YOLO session request."""
         self._continue_claude_session(event.session_id, event.path, yolo=True)
 
+    def on_start_claude_custom_session(self, event: StartClaudeCustomSession) -> None:
+        """Handle start Claude custom-button session request."""
+        self._start_claude_custom_session(event.path, event.button)
+
+    def on_continue_claude_custom_session(
+        self, event: ContinueClaudeCustomSession
+    ) -> None:
+        """Handle continue Claude custom-button session request."""
+        self._continue_claude_custom_session(event.session_id, event.path, event.button)
+
     @work
     async def on_worktree_detail_sync_requested(
         self, event: WorktreeDetail.SyncRequested
@@ -398,10 +415,6 @@ class ForestApp(App[None]):
     ) -> None:
         """Handle add worktree request."""
         await self._show_add_worktree_modal(event.repo_id)
-
-    def on_configure_claude_command(self, event: ConfigureClaudeCommand) -> None:
-        """Handle configure Claude command request."""
-        self._show_claude_command_modal(event.repo_id, event.worktree_id)
 
     @work
     async def on_repository_detail_remove_repository_requested(
@@ -820,6 +833,8 @@ class ForestApp(App[None]):
         if result:
             self._settings_service.save_settings(result)
             self.notify("Settings saved")
+            # Re-render so custom button changes take effect
+            await self._refresh_detail_pane()
 
     async def action_refresh(self) -> None:
         """Refresh the UI."""
@@ -913,95 +928,10 @@ class ForestApp(App[None]):
         else:
             self.notify("Failed to create mc window", severity="error")
 
-    @work
-    async def _show_claude_command_modal(
-        self, repo_id: UUID, worktree_id: UUID | None = None
-    ) -> None:
-        """Show the Claude command configuration modal."""
-        repo = self._state.find_repository(repo_id)
-        if not repo:
-            return
-
-        # Determine if configuring worktree or repository
-        if worktree_id:
-            worktree = repo.find_worktree(worktree_id)
-            if not worktree:
-                return
-            name = f"{repo.name}:{worktree.name}"
-            current_command = worktree.custom_claude_command
-            is_worktree = True
-        else:
-            name = repo.name
-            current_command = repo.custom_claude_command
-            is_worktree = False
-
-        result: ClaudeCommandResult = await self.push_screen_wait(
-            ClaudeCommandModal(name, current_command, is_worktree=is_worktree)
-        )
-
-        if result.cancelled:
-            return
-
-        # Update the appropriate level
-        if worktree_id:
-            self._state.update_worktree_command(worktree_id, result.command)
-            target = f"{repo.name}:{worktree.name}"  # type: ignore[union-attr]
-        else:
-            self._state.update_repository_command(repo_id, result.command)
-            target = repo.name
-
-        await self._refresh_detail_pane()
-        if result.command:
-            self.notify(f"Custom Claude command set for {target}")
-        else:
-            self.notify(f"Custom Claude command cleared for {target}")
-
-    def _find_repo_for_path(self, path: str) -> Repository | None:
-        """Find the repository associated with a path (worktree or source)."""
-        for repo in self._state.repositories:
-            if repo.source_path == path:
-                return repo
-            for worktree in repo.worktrees:
-                if worktree.path == path:
-                    return repo
-        return None
-
-    def _resolve_claude_command(self, path: str) -> str | None:
-        """Resolve Claude command with hierarchy: worktree > repo > folder > default.
-
-        Args:
-            path: The path to check for associated repository/worktree
-
-        Returns:
-            Custom command if set, None to use default "claude"
-        """
-        # Check worktree-level and repo-level
-        for repo in self._state.repositories:
-            # Check worktrees first (most specific)
-            for worktree in repo.worktrees:
-                if worktree.path == path:
-                    if worktree.custom_claude_command:
-                        return worktree.custom_claude_command
-                    if repo.custom_claude_command:
-                        return repo.custom_claude_command
-                    break
-            # Check repository source path
-            if repo.source_path == path:
-                if repo.custom_claude_command:
-                    return repo.custom_claude_command
-                break
-
-        # Fall back to folder-level setting
-        settings = self._settings_service.settings
-        return settings.custom_claude_command
-
     def _start_claude_session(self, path: str, yolo: bool = False) -> None:
         """Start a new Claude session in a tmux window."""
         name = self._get_tmux_window_name(path)
-        custom_command = self._resolve_claude_command(path)
-        window_name = self._tmux_service.create_claude_window(
-            name, path, yolo=yolo, custom_command=custom_command
-        )
+        window_name = self._tmux_service.create_claude_window(name, path, yolo=yolo)
         if window_name:
             mode = " (YOLO)" if yolo else ""
             self.notify(f"Started Claude{mode} in {window_name}")
@@ -1013,17 +943,48 @@ class ForestApp(App[None]):
     ) -> None:
         """Continue an existing Claude session in a tmux window."""
         name = self._get_tmux_window_name(path)
-        custom_command = self._resolve_claude_command(path)
         window_name = self._tmux_service.create_claude_window(
             name,
             path,
             resume_session_id=session_id,
             yolo=yolo,
-            custom_command=custom_command,
         )
         if window_name:
             mode = " (YOLO)" if yolo else ""
             self.notify(f"Resuming Claude{mode} in {window_name}")
+        else:
+            self.notify("Failed to create Claude window", severity="error")
+
+    def _start_claude_custom_session(
+        self, path: str, button: CustomClaudeButton
+    ) -> None:
+        """Start a Claude session using a custom button's command and prefix."""
+        name = self._get_tmux_window_name(path)
+        window_name = self._tmux_service.create_claude_window(
+            name,
+            path,
+            custom_command=button.command,
+            custom_prefix=button.prefix,
+        )
+        if window_name:
+            self.notify(f"Started Claude ({button.label}) in {window_name}")
+        else:
+            self.notify("Failed to create Claude window", severity="error")
+
+    def _continue_claude_custom_session(
+        self, session_id: str, path: str, button: CustomClaudeButton
+    ) -> None:
+        """Continue a Claude session using a custom button's command and prefix."""
+        name = self._get_tmux_window_name(path)
+        window_name = self._tmux_service.create_claude_window(
+            name,
+            path,
+            resume_session_id=session_id,
+            custom_command=button.command,
+            custom_prefix=button.prefix,
+        )
+        if window_name:
+            self.notify(f"Resuming Claude ({button.label}) in {window_name}")
         else:
             self.notify("Failed to create Claude window", severity="error")
 

--- a/forestui/components/messages.py
+++ b/forestui/components/messages.py
@@ -1,8 +1,8 @@
 """Shared message classes for detail view components."""
 
-from uuid import UUID
-
 from textual.message import Message
+
+from forestui.models import CustomClaudeButton
 
 
 class OpenInEditor(Message):
@@ -63,14 +63,20 @@ class ContinueClaudeYoloSession(Message):
         super().__init__()
 
 
-class ConfigureClaudeCommand(Message):
-    """Request to configure custom Claude command for a repository or worktree."""
+class StartClaudeCustomSession(Message):
+    """Request to start a new Claude session using a custom button."""
 
-    def __init__(
-        self,
-        repo_id: UUID,
-        worktree_id: UUID | None = None,
-    ) -> None:
-        self.repo_id = repo_id
-        self.worktree_id = worktree_id
+    def __init__(self, path: str, button: CustomClaudeButton) -> None:
+        self.path = path
+        self.button = button
+        super().__init__()
+
+
+class ContinueClaudeCustomSession(Message):
+    """Request to continue an existing Claude session using a custom button."""
+
+    def __init__(self, session_id: str, path: str, button: CustomClaudeButton) -> None:
+        self.session_id = session_id
+        self.path = path
+        self.button = button
         super().__init__()

--- a/forestui/components/modals.py
+++ b/forestui/components/modals.py
@@ -3,11 +3,13 @@
 from pathlib import Path
 from uuid import UUID
 
+from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.message import Message
 from textual.screen import ModalScreen
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.widgets import Button, Checkbox, Input, Label, Select
 
 from forestui.components.branch_search import (
@@ -15,11 +17,16 @@ from forestui.components.branch_search import (
     FuzzyBranchSuggester,
 )
 from forestui.models import (
+    MAX_BUTTON_LABEL_LENGTH,
+    MAX_BUTTON_PREFIX_LENGTH,
     MAX_CLAUDE_COMMAND_LENGTH,
-    ClaudeCommandResult,
+    CustomClaudeButton,
     GitHubIssue,
     Repository,
     Settings,
+    derive_prefix,
+    validate_button_label,
+    validate_button_prefix,
     validate_claude_command,
 )
 
@@ -376,13 +383,14 @@ class SettingsModal(ModalScreen[Settings | None]):
     def __init__(self, settings: Settings) -> None:
         super().__init__()
         self._settings = settings
+        self._custom_buttons: list[CustomClaudeButton] = list(settings.custom_buttons)
 
     def compose(self) -> ComposeResult:
         """Compose the modal UI."""
-        with Vertical(classes="modal-container"):
+        with Vertical(classes="modal-container modal-wide"):
             yield Label(" Settings", classes="modal-title")
 
-            with VerticalScroll(classes="modal-scroll"):
+            with VerticalScroll(classes="modal-scroll modal-scroll-tall"):
                 yield Label("DEFAULT EDITOR", classes="section-header")
                 yield Select(
                     [(name, cmd) for name, cmd in self.EDITORS],
@@ -404,26 +412,30 @@ class SettingsModal(ModalScreen[Settings | None]):
                     id="select-theme",
                 )
 
-                yield Label("CUSTOM CLAUDE COMMAND", classes="section-header")
-                yield Input(
-                    value=self._settings.custom_claude_command or "",
-                    id="input-custom-claude-command",
-                    placeholder="e.g., claude --model opus",
-                    max_length=MAX_CLAUDE_COMMAND_LENGTH,
-                )
+                yield Label("CUSTOM CLAUDE BUTTONS", classes="section-header")
                 yield Label(
-                    "Default command for all repos",
+                    self._buttons_summary(),
+                    id="label-buttons-count",
                     classes="label-muted",
                 )
-                yield Label(
-                    "Can be overridden per-repo",
-                    classes="label-muted",
-                )
-                yield Label("", id="label-claude-error", classes="label-destructive")
+                with Horizontal(classes="action-row"):
+                    yield Button(
+                        "Manage Custom Buttons...",
+                        id="btn-manage-buttons",
+                        variant="default",
+                    )
 
             with Horizontal(classes="modal-buttons"):
                 yield Button("Cancel", id="btn-cancel", variant="default")
                 yield Button("Save", id="btn-save", variant="primary")
+
+    def _buttons_summary(self) -> str:
+        count = len(self._custom_buttons)
+        if count == 0:
+            return "No custom buttons configured"
+        if count == 1:
+            return "1 custom button configured"
+        return f"{count} custom buttons configured"
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""
@@ -431,6 +443,20 @@ class SettingsModal(ModalScreen[Settings | None]):
             self.dismiss(None)
         elif event.button.id == "btn-save":
             self._save_settings()
+        elif event.button.id == "btn-manage-buttons":
+            self._manage_buttons()
+
+    @work
+    async def _manage_buttons(self) -> None:
+        """Open the custom-buttons sub-modal and store the returned list."""
+        result = await self.app.push_screen_wait(
+            CustomButtonsModal(self._custom_buttons)
+        )
+        if result is not None:
+            self._custom_buttons = result
+            self.query_one("#label-buttons-count", Label).update(
+                self._buttons_summary()
+            )
 
     def _save_settings(self) -> None:
         """Save the settings."""
@@ -439,24 +465,12 @@ class SettingsModal(ModalScreen[Settings | None]):
         branch_prefix = self.query_one("#input-branch-prefix", Input).value
         theme_select = self.query_one("#select-theme", Select)
         theme = str(theme_select.value) if theme_select.value else "system"
-        custom_claude_command = (
-            self.query_one("#input-custom-claude-command", Input).value.strip() or None
-        )
-
-        # Validate custom claude command
-        error_label = self.query_one("#label-claude-error", Label)
-        if custom_claude_command:
-            error = validate_claude_command(custom_claude_command)
-            if error:
-                error_label.update(f" {error}")
-                return
-        error_label.update("")
 
         new_settings = Settings(
             default_editor=editor,
             branch_prefix=branch_prefix,
             theme=theme,
-            custom_claude_command=custom_claude_command,
+            custom_buttons=self._custom_buttons,
         )
 
         self.dismiss(new_settings)
@@ -735,95 +749,263 @@ class CreateWorktreeFromIssueModal(ModalScreen[tuple[str, str, bool, bool] | Non
         self.dismiss(None)
 
 
-class ClaudeCommandModal(ModalScreen[ClaudeCommandResult]):
-    """Modal for editing custom Claude command for a repository or worktree."""
+class CustomButtonEditModal(ModalScreen[CustomClaudeButton | None]):
+    """Modal for adding or editing a single CustomClaudeButton."""
 
-    BINDINGS = [
-        ("escape", "cancel", "Cancel"),
-    ]
-
-    # Common command presets
-    PRESETS = [
-        ("claude", "claude"),
-        ("opus", "claude --model opus"),
-        ("sonnet", "claude --model sonnet"),
-    ]
+    BINDINGS = [("escape", "cancel", "Cancel")]
 
     def __init__(
         self,
-        name: str,
-        current_command: str | None,
-        *,
-        is_worktree: bool = False,
+        existing: CustomClaudeButton | None,
+        other_labels: set[str],
+        other_prefixes: set[str],
     ) -> None:
         super().__init__()
-        self._name = name
-        self._current_command = current_command
-        self._is_worktree = is_worktree
+        self._existing = existing
+        self._other_labels = other_labels
+        self._other_prefixes = other_prefixes
+        # Track whether prefix should auto-follow the label
+        if existing is None:
+            self._follows = True
+        else:
+            self._follows = existing.prefix == derive_prefix(existing.label)
+        self._suppress_prefix_event = False
 
     def compose(self) -> ComposeResult:
-        """Compose the modal UI."""
-        with Vertical(classes="modal-container"):
-            yield Label(" Custom Claude Command", classes="modal-title")
-            yield Label(f"for {self._name}", classes="label-secondary")
+        title = "Edit Button" if self._existing else "Add Button"
+        label_val = self._existing.label if self._existing else ""
+        prefix_val = self._existing.prefix if self._existing else ""
+        cmd_val = self._existing.command if self._existing else ""
 
-            yield Label("PRESETS", classes="section-header")
-            with Horizontal(classes="action-row"):
-                for label, _cmd in self.PRESETS:
-                    yield Button(label, id=f"btn-preset-{label}", variant="default")
+        with Vertical(classes="modal-container"):
+            yield Label(f" {title}", classes="modal-title")
+
+            yield Label("LABEL", classes="section-header")
+            yield Input(
+                value=label_val,
+                id="input-label",
+                placeholder="e.g., YoloDisc",
+                max_length=MAX_BUTTON_LABEL_LENGTH,
+            )
+            yield Label(
+                "Shown on the button (e.g., 'New Session: YoloDisc')",
+                classes="label-muted",
+            )
+
+            yield Label("TMUX PREFIX", classes="section-header")
+            yield Input(
+                value=prefix_val,
+                id="input-prefix",
+                placeholder="e.g., yolodisc",
+                max_length=MAX_BUTTON_PREFIX_LENGTH,
+            )
+            yield Label(
+                "Window prefix: <prefix>:<worktree>. Auto-derived from label "
+                "until you edit it.",
+                classes="label-muted",
+            )
 
             yield Label("COMMAND", classes="section-header")
             yield Input(
-                value=self._current_command or "",
-                id="input-claude-command",
-                placeholder="e.g., claude --model opus",
+                value=cmd_val,
+                id="input-command",
+                placeholder="e.g., claude --dangerously-skip-permissions",
                 max_length=MAX_CLAUDE_COMMAND_LENGTH,
             )
-            fallback = "repo default" if self._is_worktree else "folder default"
             yield Label(
-                f"Leave empty to use {fallback}",
+                "Run as-is. If it contains --dangerously-skip-permissions "
+                "the button is styled red.",
                 classes="label-muted",
             )
-            yield Label("", id="label-error", classes="label-destructive")
+
+            yield Label("", id="label-edit-error", classes="label-destructive")
 
             with Horizontal(classes="modal-buttons"):
                 yield Button("Cancel", id="btn-cancel", variant="default")
                 yield Button("Save", id="btn-save", variant="primary")
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "input-label":
+            if self._follows:
+                self._suppress_prefix_event = True
+                self.query_one("#input-prefix", Input).value = derive_prefix(
+                    event.value
+                )
+                self._suppress_prefix_event = False
+        elif event.input.id == "input-prefix":
+            if self._suppress_prefix_event:
+                return
+            label = self.query_one("#input-label", Input).value
+            self._follows = event.value == derive_prefix(label)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle button presses."""
-        btn_id = event.button.id or ""
+        if event.button.id == "btn-cancel":
+            self.dismiss(None)
+        elif event.button.id == "btn-save":
+            self._save()
 
-        if btn_id == "btn-cancel":
-            self.dismiss(ClaudeCommandResult(command=None, cancelled=True))
-        elif btn_id == "btn-save":
-            self._save_command()
-        elif btn_id.startswith("btn-preset-"):
-            # Handle preset buttons
-            preset_label = btn_id.replace("btn-preset-", "")
-            for label, cmd in self.PRESETS:
-                if label == preset_label:
-                    self.query_one("#input-claude-command", Input).value = cmd
-                    break
+    def _save(self) -> None:
+        label = self.query_one("#input-label", Input).value.strip()
+        prefix = self.query_one("#input-prefix", Input).value.strip()
+        command = self.query_one("#input-command", Input).value.strip()
+        err_label = self.query_one("#label-edit-error", Label)
 
-    def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Handle enter key in input."""
-        if event.input.id == "input-claude-command":
-            self._save_command()
+        for error in (
+            validate_button_label(label),
+            validate_button_prefix(prefix),
+            validate_claude_command(command) if command else "Command cannot be empty",
+        ):
+            if error:
+                err_label.update(f" {error}")
+                return
 
-    def _save_command(self) -> None:
-        """Save the custom command."""
-        command = self.query_one("#input-claude-command", Input).value.strip()
-        error_label = self.query_one("#label-error", Label)
-
-        error = validate_claude_command(command)
-        if error:
-            error_label.update(f" {error}")
+        if label in self._other_labels:
+            err_label.update(" Another button already uses this label")
+            return
+        if prefix in self._other_prefixes:
+            err_label.update(" Another button already uses this prefix")
             return
 
-        # Return None command to clear the setting, or the command string
-        self.dismiss(ClaudeCommandResult(command=command if command else None))
+        err_label.update("")
+        self.dismiss(CustomClaudeButton(label=label, prefix=prefix, command=command))
 
     def action_cancel(self) -> None:
-        """Cancel and close the modal."""
-        self.dismiss(ClaudeCommandResult(command=None, cancelled=True))
+        self.dismiss(None)
+
+
+class CustomButtonsModal(ModalScreen[list[CustomClaudeButton] | None]):
+    """Modal for managing (add/edit/delete/reorder) custom Claude buttons."""
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(self, buttons: list[CustomClaudeButton]) -> None:
+        super().__init__()
+        # Work on a copy so cancel discards changes
+        self._buttons: list[CustomClaudeButton] = [b.model_copy() for b in buttons]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="modal-container modal-wide"):
+            yield Label(" Custom Claude Buttons", classes="modal-title")
+            yield Label(
+                "Order here matches display order in the Claude section.",
+                classes="label-muted",
+            )
+
+            with VerticalScroll(
+                classes="modal-scroll modal-scroll-tall",
+                id="buttons-list",
+            ):
+                yield from self._build_rows()
+
+            with Horizontal(classes="action-row"):
+                yield Button(" Add Button", id="btn-add", variant="primary")
+
+            with Horizontal(classes="modal-buttons"):
+                yield Button("Cancel", id="btn-cancel", variant="default")
+                yield Button("Save", id="btn-save", variant="primary")
+
+    def _build_rows(self) -> list[Widget]:
+        """Build the concrete widget list for the buttons scroll area."""
+        if not self._buttons:
+            return [Label("No buttons yet. Click Add.", classes="label-muted")]
+        rows: list[Widget] = []
+        last = len(self._buttons) - 1
+        for idx, btn in enumerate(self._buttons):
+            yolo_note = " (YOLO)" if btn.is_yolo_style else ""
+            info = Vertical(
+                Label(f"{btn.label}{yolo_note}", classes="session-title"),
+                Label(f"prefix: {btn.prefix}", classes="session-meta label-muted"),
+                Label(f"$ {btn.command}", classes="session-meta label-muted"),
+                classes="session-info",
+            )
+            buttons = Horizontal(
+                Button(
+                    "↑",
+                    id=f"btn-up-{idx}",
+                    classes="session-btn",
+                    disabled=idx == 0,
+                ),
+                Button(
+                    "↓",
+                    id=f"btn-down-{idx}",
+                    classes="session-btn",
+                    disabled=idx == last,
+                ),
+                Button("Edit", id=f"btn-edit-{idx}", classes="session-btn"),
+                Button(
+                    "Delete",
+                    id=f"btn-delete-{idx}",
+                    classes="session-btn -destructive",
+                    variant="error",
+                ),
+                classes="session-buttons",
+            )
+            rows.append(
+                Vertical(
+                    Horizontal(info, buttons, classes="session-header-row"),
+                    classes="session-item",
+                )
+            )
+        return rows
+
+    def _rerender(self) -> None:
+        """Rebuild the list container after add/edit/delete/reorder."""
+        container = self.query_one("#buttons-list", VerticalScroll)
+        container.remove_children()
+        container.mount_all(self._build_rows())
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        btn_id = event.button.id or ""
+        if btn_id == "btn-cancel":
+            self.dismiss(None)
+        elif btn_id == "btn-save":
+            self.dismiss(self._buttons)
+        elif btn_id == "btn-add":
+            self._add_button()
+        elif btn_id.startswith("btn-up-"):
+            self._swap(int(btn_id.removeprefix("btn-up-")), -1)
+        elif btn_id.startswith("btn-down-"):
+            self._swap(int(btn_id.removeprefix("btn-down-")), 1)
+        elif btn_id.startswith("btn-edit-"):
+            self._edit_button(int(btn_id.removeprefix("btn-edit-")))
+        elif btn_id.startswith("btn-delete-"):
+            idx = int(btn_id.removeprefix("btn-delete-"))
+            self._buttons.pop(idx)
+            self._rerender()
+
+    def _swap(self, idx: int, delta: int) -> None:
+        j = idx + delta
+        if 0 <= j < len(self._buttons):
+            self._buttons[idx], self._buttons[j] = self._buttons[j], self._buttons[idx]
+            self._rerender()
+
+    @work
+    async def _add_button(self) -> None:
+        result = await self.app.push_screen_wait(
+            CustomButtonEditModal(
+                existing=None,
+                other_labels={b.label for b in self._buttons},
+                other_prefixes={b.prefix for b in self._buttons},
+            )
+        )
+        if result is not None:
+            self._buttons.append(result)
+            self._rerender()
+
+    @work
+    async def _edit_button(self, idx: int) -> None:
+        existing = self._buttons[idx]
+        others = [b for i, b in enumerate(self._buttons) if i != idx]
+        result = await self.app.push_screen_wait(
+            CustomButtonEditModal(
+                existing=existing,
+                other_labels={b.label for b in others},
+                other_prefixes={b.prefix for b in others},
+            )
+        )
+        if result is not None:
+            self._buttons[idx] = result
+            self._rerender()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/forestui/components/repository_detail.py
+++ b/forestui/components/repository_detail.py
@@ -12,16 +12,22 @@ from textual.widget import Widget
 from textual.widgets import Button, Label, Rule
 
 from forestui.components.messages import (
-    ConfigureClaudeCommand,
+    ContinueClaudeCustomSession,
     ContinueClaudeSession,
     ContinueClaudeYoloSession,
     OpenInEditor,
     OpenInFileManager,
     OpenInTerminal,
+    StartClaudeCustomSession,
     StartClaudeSession,
     StartClaudeYoloSession,
 )
-from forestui.models import ClaudeSession, GitHubIssue, Repository
+from forestui.models import (
+    ClaudeSession,
+    CustomClaudeButton,
+    GitHubIssue,
+    Repository,
+)
 
 
 class RepositoryDetail(Widget):
@@ -71,6 +77,7 @@ class RepositoryDetail(Widget):
         commit_hash: str = "",
         commit_time: datetime | None = None,
         has_remote: bool = True,
+        custom_buttons: list[CustomClaudeButton] | None = None,
     ) -> None:
         super().__init__()
         self._repository = repository
@@ -84,6 +91,10 @@ class RepositoryDetail(Widget):
         self._spinner_chars = "|/-\\"
         self._spinner_index = 0
         self._spinner_timer: Timer | None = None
+        self._custom_buttons: list[CustomClaudeButton] = list(custom_buttons or [])
+        self._buttons_by_prefix: dict[str, CustomClaudeButton] = {
+            b.prefix: b for b in self._custom_buttons
+        }
 
     def compose(self) -> ComposeResult:
         """Compose the repository detail view."""
@@ -111,7 +122,7 @@ class RepositoryDetail(Widget):
                     if relative_time:
                         commit_text += f" ({relative_time})"
                     yield Label(commit_text, classes="label-muted")
-                # Sync button
+                # Sync + Add Worktree
                 with Horizontal(classes="action-row"):
                     if self._has_remote:
                         yield Button("⟳ Git Pull", id="btn-sync", variant="default")
@@ -122,6 +133,9 @@ class RepositoryDetail(Widget):
                             variant="default",
                             disabled=True,
                         )
+                    yield Button(
+                        " Add Worktree", id="btn-add-worktree", variant="default"
+                    )
 
             yield Rule()
 
@@ -143,17 +157,45 @@ class RepositoryDetail(Widget):
 
             yield Rule()
 
-            # Claude section
+            # Claude section — buttons wrap to multiple rows when they don't fit.
             yield Label("CLAUDE", classes="section-header")
-            with Horizontal(classes="action-row"):
-                yield Button("New Session", id="btn-claude-new", variant="primary")
-                yield Button(
-                    "New Session: YOLO",
-                    id="btn-claude-yolo",
-                    variant="error",
-                    classes="-destructive",
-                )
-                yield Button(" Add Worktree", id="btn-add-worktree", variant="default")
+            # (label, id, variant, is_destructive)
+            claude_specs: list[tuple[str, str, str, bool]] = [
+                ("New Session", "btn-claude-new", "primary", False),
+                ("New Session: YOLO", "btn-claude-yolo", "error", True),
+            ]
+            for btn in self._custom_buttons:
+                if btn.is_yolo_style:
+                    claude_specs.append(
+                        (btn.label, f"btn-claude-custom-{btn.prefix}", "error", True)
+                    )
+                else:
+                    claude_specs.append(
+                        (
+                            btn.label,
+                            f"btn-claude-custom-{btn.prefix}",
+                            "primary",
+                            False,
+                        )
+                    )
+            for chunk_start in range(0, len(claude_specs), 4):
+                with Horizontal(classes="action-row"):
+                    for label, btn_id, variant, is_dest in claude_specs[
+                        chunk_start : chunk_start + 4
+                    ]:
+                        if is_dest:
+                            yield Button(
+                                label,
+                                id=btn_id,
+                                variant=variant,  # type: ignore[arg-type]
+                                classes="-destructive",
+                            )
+                        else:
+                            yield Button(
+                                label,
+                                id=btn_id,
+                                variant=variant,  # type: ignore[arg-type]
+                            )
 
             # Sessions list (loaded async)
             yield Label("RECENT SESSIONS", classes="section-header")
@@ -173,11 +215,6 @@ class RepositoryDetail(Widget):
             # Manage section
             yield Label("MANAGE", classes="section-header")
             with Horizontal(classes="action-row"):
-                yield Button(
-                    " Custom Claude Command",
-                    id="btn-configure-claude",
-                    variant="default",
-                )
                 yield Button(
                     " Remove Repository",
                     id="btn-remove-repo",
@@ -201,8 +238,6 @@ class RepositoryDetail(Widget):
                 self.post_message(StartClaudeSession(path))
             case "btn-claude-yolo":
                 self.post_message(StartClaudeYoloSession(path))
-            case "btn-configure-claude":
-                self.post_message(ConfigureClaudeCommand(self._repository.id))
             case "btn-add-worktree":
                 self.post_message(self.AddWorktreeRequested(self._repository.id))
             case "btn-remove-repo":
@@ -224,6 +259,23 @@ class RepositoryDetail(Widget):
             case _ if btn_id.startswith("btn-yolo-"):
                 session_id = btn_id.replace("btn-yolo-", "")
                 self.post_message(ContinueClaudeYoloSession(session_id, path))
+            case _ if btn_id.startswith("btn-claude-custom-"):
+                prefix = btn_id.removeprefix("btn-claude-custom-")
+                custom = self._buttons_by_prefix.get(prefix)
+                if custom:
+                    self.post_message(StartClaudeCustomSession(path, custom))
+            case _ if btn_id.startswith("btn-custom-"):
+                # Format: btn-custom-<prefix>-<session_id>
+                rest = btn_id.removeprefix("btn-custom-")
+                for prefix in self._buttons_by_prefix:
+                    marker = f"{prefix}-"
+                    if rest.startswith(marker):
+                        session_id = rest.removeprefix(marker)
+                        custom = self._buttons_by_prefix[prefix]
+                        self.post_message(
+                            ContinueClaudeCustomSession(session_id, path, custom)
+                        )
+                        break
             case _ if btn_id.startswith("btn-issue-"):
                 issue_num = int(btn_id.replace("btn-issue-", ""))
                 issue = self._issues_by_number.get(issue_num)
@@ -267,29 +319,58 @@ class RepositoryDetail(Widget):
                         Label(meta, classes="session-meta label-muted")
                     )
 
-                    row = Vertical(
-                        Horizontal(
-                            Vertical(*info_children, classes="session-info"),
-                            Horizontal(
-                                Button(
-                                    "Resume",
-                                    id=f"btn-resume-{session.id}",
-                                    variant="default",
-                                    classes="session-btn",
-                                ),
-                                Button(
-                                    "YOLO",
-                                    id=f"btn-yolo-{session.id}",
-                                    variant="error",
-                                    classes="session-btn -destructive",
-                                ),
-                                classes="session-buttons",
-                            ),
-                            classes="session-header-row",
-                        ),
-                        classes="session-item",
-                    )
-                    container.mount(row)
+                    # (label, id, variant, is_destructive)
+                    btn_specs: list[tuple[str, str, str, bool]] = [
+                        ("Resume", f"btn-resume-{session.id}", "default", False),
+                        ("YOLO", f"btn-yolo-{session.id}", "error", True),
+                    ]
+                    for cbtn in self._custom_buttons:
+                        if cbtn.is_yolo_style:
+                            btn_specs.append(
+                                (
+                                    cbtn.label,
+                                    f"btn-custom-{cbtn.prefix}-{session.id}",
+                                    "error",
+                                    True,
+                                )
+                            )
+                        else:
+                            btn_specs.append(
+                                (
+                                    cbtn.label,
+                                    f"btn-custom-{cbtn.prefix}-{session.id}",
+                                    "primary",
+                                    False,
+                                )
+                            )
+                    children: list[Widget] = [*info_children]
+                    for chunk_start in range(0, len(btn_specs), 4):
+                        row_buttons: list[Button] = []
+                        for label, btn_id, variant, is_dest in btn_specs[
+                            chunk_start : chunk_start + 4
+                        ]:
+                            if is_dest:
+                                row_buttons.append(
+                                    Button(
+                                        label,
+                                        id=btn_id,
+                                        variant=variant,  # type: ignore[arg-type]
+                                        classes="session-btn -destructive",
+                                    )
+                                )
+                            else:
+                                row_buttons.append(
+                                    Button(
+                                        label,
+                                        id=btn_id,
+                                        variant=variant,  # type: ignore[arg-type]
+                                        classes="session-btn",
+                                    )
+                                )
+                        children.append(
+                            Horizontal(*row_buttons, classes="session-buttons")
+                        )
+                    container.mount(Vertical(*children, classes="session-item"))
             else:
                 container.mount(Label("No sessions found", classes="label-muted"))
         except Exception:

--- a/forestui/components/worktree_detail.py
+++ b/forestui/components/worktree_detail.py
@@ -11,16 +11,17 @@ from textual.widget import Widget
 from textual.widgets import Button, Input, Label, Rule
 
 from forestui.components.messages import (
-    ConfigureClaudeCommand,
+    ContinueClaudeCustomSession,
     ContinueClaudeSession,
     ContinueClaudeYoloSession,
     OpenInEditor,
     OpenInFileManager,
     OpenInTerminal,
+    StartClaudeCustomSession,
     StartClaudeSession,
     StartClaudeYoloSession,
 )
-from forestui.models import ClaudeSession, Repository, Worktree
+from forestui.models import ClaudeSession, CustomClaudeButton, Repository, Worktree
 
 
 class WorktreeDetail(Widget):
@@ -79,6 +80,7 @@ class WorktreeDetail(Widget):
         commit_hash: str = "",
         commit_time: datetime | None = None,
         has_remote: bool = True,
+        custom_buttons: list[CustomClaudeButton] | None = None,
     ) -> None:
         super().__init__()
         self._repository = repository
@@ -87,6 +89,10 @@ class WorktreeDetail(Widget):
         self._commit_time = commit_time
         self._has_remote = has_remote
         self._sessions: list[ClaudeSession] = []
+        self._custom_buttons: list[CustomClaudeButton] = list(custom_buttons or [])
+        self._buttons_by_prefix: dict[str, CustomClaudeButton] = {
+            b.prefix: b for b in self._custom_buttons
+        }
 
     def compose(self) -> ComposeResult:
         """Compose the worktree detail view."""
@@ -155,16 +161,45 @@ class WorktreeDetail(Widget):
 
             yield Rule()
 
-            # Claude section
+            # Claude section — buttons wrap to multiple rows when they don't fit.
             yield Label("CLAUDE", classes="section-header")
-            with Horizontal(classes="action-row"):
-                yield Button("New Session", id="btn-claude-new", variant="primary")
-                yield Button(
-                    "New Session: YOLO",
-                    id="btn-claude-yolo",
-                    variant="error",
-                    classes="-destructive",
-                )
+            # (label, id, variant, is_destructive)
+            claude_specs: list[tuple[str, str, str, bool]] = [
+                ("New Session", "btn-claude-new", "primary", False),
+                ("New Session: YOLO", "btn-claude-yolo", "error", True),
+            ]
+            for btn in self._custom_buttons:
+                if btn.is_yolo_style:
+                    claude_specs.append(
+                        (btn.label, f"btn-claude-custom-{btn.prefix}", "error", True)
+                    )
+                else:
+                    claude_specs.append(
+                        (
+                            btn.label,
+                            f"btn-claude-custom-{btn.prefix}",
+                            "primary",
+                            False,
+                        )
+                    )
+            for chunk_start in range(0, len(claude_specs), 4):
+                with Horizontal(classes="action-row"):
+                    for label, btn_id, variant, is_dest in claude_specs[
+                        chunk_start : chunk_start + 4
+                    ]:
+                        if is_dest:
+                            yield Button(
+                                label,
+                                id=btn_id,
+                                variant=variant,  # type: ignore[arg-type]
+                                classes="-destructive",
+                            )
+                        else:
+                            yield Button(
+                                label,
+                                id=btn_id,
+                                variant=variant,  # type: ignore[arg-type]
+                            )
 
             # Sessions list (loaded async)
             yield Label("RECENT SESSIONS", classes="section-header")
@@ -193,11 +228,6 @@ class WorktreeDetail(Widget):
             # Manage section
             yield Label("MANAGE", classes="section-header")
             with Horizontal(classes="action-row"):
-                yield Button(
-                    " Custom Claude Command",
-                    id="btn-configure-claude",
-                    variant="default",
-                )
                 if self._worktree.is_archived:
                     yield Button(
                         " Unarchive",
@@ -233,10 +263,6 @@ class WorktreeDetail(Widget):
                 self.post_message(StartClaudeSession(path))
             case "btn-claude-yolo":
                 self.post_message(StartClaudeYoloSession(path))
-            case "btn-configure-claude":
-                self.post_message(
-                    ConfigureClaudeCommand(self._repository.id, self._worktree.id)
-                )
             case "btn-archive":
                 self.post_message(self.ArchiveWorktreeRequested(self._worktree.id))
             case "btn-unarchive":
@@ -253,6 +279,23 @@ class WorktreeDetail(Widget):
             case _ if btn_id.startswith("btn-yolo-"):
                 session_id = btn_id.replace("btn-yolo-", "")
                 self.post_message(ContinueClaudeYoloSession(session_id, path))
+            case _ if btn_id.startswith("btn-claude-custom-"):
+                prefix = btn_id.removeprefix("btn-claude-custom-")
+                custom = self._buttons_by_prefix.get(prefix)
+                if custom:
+                    self.post_message(StartClaudeCustomSession(path, custom))
+            case _ if btn_id.startswith("btn-custom-"):
+                # Format: btn-custom-<prefix>-<session_id>
+                rest = btn_id.removeprefix("btn-custom-")
+                for prefix in self._buttons_by_prefix:
+                    marker = f"{prefix}-"
+                    if rest.startswith(marker):
+                        session_id = rest.removeprefix(marker)
+                        custom = self._buttons_by_prefix[prefix]
+                        self.post_message(
+                            ContinueClaudeCustomSession(session_id, path, custom)
+                        )
+                        break
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle input submission."""
@@ -303,29 +346,58 @@ class WorktreeDetail(Widget):
                         Label(meta, classes="session-meta label-muted")
                     )
 
-                    row = Vertical(
-                        Horizontal(
-                            Vertical(*info_children, classes="session-info"),
-                            Horizontal(
-                                Button(
-                                    "Resume",
-                                    id=f"btn-resume-{session.id}",
-                                    variant="default",
-                                    classes="session-btn",
-                                ),
-                                Button(
-                                    "YOLO",
-                                    id=f"btn-yolo-{session.id}",
-                                    variant="error",
-                                    classes="session-btn -destructive",
-                                ),
-                                classes="session-buttons",
-                            ),
-                            classes="session-header-row",
-                        ),
-                        classes="session-item",
-                    )
-                    container.mount(row)
+                    # (label, id, variant, is_destructive)
+                    btn_specs: list[tuple[str, str, str, bool]] = [
+                        ("Resume", f"btn-resume-{session.id}", "default", False),
+                        ("YOLO", f"btn-yolo-{session.id}", "error", True),
+                    ]
+                    for cbtn in self._custom_buttons:
+                        if cbtn.is_yolo_style:
+                            btn_specs.append(
+                                (
+                                    cbtn.label,
+                                    f"btn-custom-{cbtn.prefix}-{session.id}",
+                                    "error",
+                                    True,
+                                )
+                            )
+                        else:
+                            btn_specs.append(
+                                (
+                                    cbtn.label,
+                                    f"btn-custom-{cbtn.prefix}-{session.id}",
+                                    "primary",
+                                    False,
+                                )
+                            )
+                    children: list[Widget] = [*info_children]
+                    for chunk_start in range(0, len(btn_specs), 4):
+                        row_buttons: list[Button] = []
+                        for label, btn_id, variant, is_dest in btn_specs[
+                            chunk_start : chunk_start + 4
+                        ]:
+                            if is_dest:
+                                row_buttons.append(
+                                    Button(
+                                        label,
+                                        id=btn_id,
+                                        variant=variant,  # type: ignore[arg-type]
+                                        classes="session-btn -destructive",
+                                    )
+                                )
+                            else:
+                                row_buttons.append(
+                                    Button(
+                                        label,
+                                        id=btn_id,
+                                        variant=variant,  # type: ignore[arg-type]
+                                        classes="session-btn",
+                                    )
+                                )
+                        children.append(
+                            Horizontal(*row_buttons, classes="session-buttons")
+                        )
+                    container.mount(Vertical(*children, classes="session-item"))
             else:
                 container.mount(Label("No sessions found", classes="label-muted"))
         except Exception:

--- a/forestui/models.py
+++ b/forestui/models.py
@@ -1,7 +1,6 @@
 """Data models for forestui."""
 
 import re
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Self
@@ -12,6 +11,39 @@ from pydantic import BaseModel, Field, field_validator
 
 # Constants for validation
 MAX_CLAUDE_COMMAND_LENGTH = 200
+MAX_BUTTON_LABEL_LENGTH = 20
+MAX_BUTTON_PREFIX_LENGTH = 20
+
+
+def derive_prefix(label: str) -> str:
+    """Derive a tmux-safe window prefix from a button label.
+
+    Lowercase, keep [a-z0-9_-], collapse other runs to '-', strip leading/trailing '-'.
+    """
+    slug = re.sub(r"[^a-z0-9_-]+", "-", label.lower()).strip("-")
+    return slug[:MAX_BUTTON_PREFIX_LENGTH]
+
+
+def validate_button_label(label: str) -> str | None:
+    """Validate a custom button label."""
+    if not label:
+        return "Label cannot be empty"
+    if len(label) > MAX_BUTTON_LABEL_LENGTH:
+        return f"Label too long (max {MAX_BUTTON_LABEL_LENGTH} characters)"
+    if any(c in label for c in "\n\r\t\0"):
+        return "Label cannot contain control characters"
+    return None
+
+
+def validate_button_prefix(prefix: str) -> str | None:
+    """Validate a tmux window prefix."""
+    if not prefix:
+        return "Prefix cannot be empty"
+    if len(prefix) > MAX_BUTTON_PREFIX_LENGTH:
+        return f"Prefix too long (max {MAX_BUTTON_PREFIX_LENGTH} characters)"
+    if not re.fullmatch(r"[a-z0-9_-]+", prefix):
+        return "Prefix must be lowercase letters, digits, '-' or '_'"
+    return None
 
 
 def validate_claude_command(command: str) -> str | None:
@@ -35,27 +67,48 @@ def validate_claude_command(command: str) -> str | None:
     return None
 
 
-def _validate_command_field(v: str | None) -> str | None:
-    """Pydantic field validator for custom_claude_command."""
-    if v is None:
-        return None
-    error = validate_claude_command(v)
-    if error:
-        raise ValueError(error)
-    return v
+class CustomClaudeButton(BaseModel):
+    """A user-configured custom Claude command button.
 
-
-@dataclass
-class ClaudeCommandResult:
-    """Result from ClaudeCommandModal.
-
-    Attributes:
-        command: The command string, or None to clear the setting.
-        cancelled: True if user cancelled the modal.
+    `label` is what's shown on the button. `prefix` is used as the tmux window
+    prefix (e.g., "yolodisc" → "yolodisc:<name>"). `command` is run as-is; if it
+    contains --dangerously-skip-permissions the button is styled red.
     """
 
-    command: str | None
-    cancelled: bool = False
+    label: str
+    prefix: str
+    command: str
+
+    @field_validator("label")
+    @classmethod
+    def _validate_label(cls, v: str) -> str:
+        error = validate_button_label(v)
+        if error:
+            raise ValueError(error)
+        return v
+
+    @field_validator("prefix")
+    @classmethod
+    def _validate_prefix(cls, v: str) -> str:
+        error = validate_button_prefix(v)
+        if error:
+            raise ValueError(error)
+        return v
+
+    @field_validator("command")
+    @classmethod
+    def _validate_command(cls, v: str) -> str:
+        error = validate_claude_command(v)
+        if error:
+            raise ValueError(error)
+        if not v:
+            raise ValueError("Command cannot be empty")
+        return v
+
+    @property
+    def is_yolo_style(self) -> bool:
+        """Whether this button's command enables dangerous permissions bypass."""
+        return "--dangerously-skip-permissions" in self.command
 
 
 class Worktree(BaseModel):
@@ -68,17 +121,10 @@ class Worktree(BaseModel):
     is_archived: bool = False
     sort_order: int | None = None
     last_modified: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    custom_claude_command: str | None = None
     # Branch this worktree was created from (e.g., "origin/main")
     base_branch: str | None = None
     # Git commit ref when the worktree was created
     created_from_ref: str | None = None
-
-    @field_validator("custom_claude_command")
-    @classmethod
-    def validate_command(cls, v: str | None) -> str | None:
-        """Validate custom_claude_command field."""
-        return _validate_command_field(v)
 
     def get_path(self) -> Path:
         """Get the worktree path as a Path object."""
@@ -92,13 +138,6 @@ class Repository(BaseModel):
     name: str
     source_path: str
     worktrees: list[Worktree] = Field(default_factory=list)
-    custom_claude_command: str | None = None
-
-    @field_validator("custom_claude_command")
-    @classmethod
-    def validate_command(cls, v: str | None) -> str | None:
-        """Validate custom_claude_command field."""
-        return _validate_command_field(v)
 
     def get_source_path(self) -> Path:
         """Get the source path as a Path object."""
@@ -156,13 +195,7 @@ class Settings(BaseModel):
     default_terminal: str = ""
     branch_prefix: str = "feat/"
     theme: str = "system"
-    custom_claude_command: str | None = None
-
-    @field_validator("custom_claude_command")
-    @classmethod
-    def validate_command(cls, v: str | None) -> str | None:
-        """Validate custom_claude_command field."""
-        return _validate_command_field(v)
+    custom_buttons: list[CustomClaudeButton] = Field(default_factory=list)
 
     @classmethod
     def default(cls) -> Self:

--- a/forestui/services/tmux.py
+++ b/forestui/services/tmux.py
@@ -307,6 +307,7 @@ class TmuxService:
         resume_session_id: str | None = None,
         yolo: bool = False,
         custom_command: str | None = None,
+        custom_prefix: str | None = None,
     ) -> str | None:
         """Create a tmux window with Claude Code.
 
@@ -316,6 +317,9 @@ class TmuxService:
             resume_session_id: Optional session ID to resume
             yolo: If True, add --dangerously-skip-permissions flag
             custom_command: Optional custom Claude command (e.g., "claude --model opus")
+            custom_prefix: Optional tmux window prefix override (for custom buttons).
+                When set, overrides the "claude"/"yolo" prefix and the command is
+                used as-is (no --dangerously-skip-permissions is appended).
 
         Returns:
             The window name if created/selected successfully, None otherwise
@@ -323,9 +327,12 @@ class TmuxService:
         if self.session is None:
             return None
 
-        base_window_name = f"claude:{name}"
-        if yolo:
+        if custom_prefix:
+            base_window_name = f"{custom_prefix}:{name}"
+        elif yolo:
             base_window_name = f"yolo:{name}"
+        else:
+            base_window_name = f"claude:{name}"
 
         try:
             # Always create a new window with unique name (add :2, :3 suffix if needed)
@@ -334,7 +341,8 @@ class TmuxService:
             # Build claude command (closes when claude exits)
             # Use custom_command if provided, otherwise default to "claude"
             cmd = custom_command or "claude"
-            if yolo:
+            # Only append YOLO flag for the built-in YOLO button, not custom buttons
+            if yolo and not custom_prefix:
                 cmd += " --dangerously-skip-permissions"
             if resume_session_id:
                 cmd += f" -r {resume_session_id}"

--- a/forestui/state.py
+++ b/forestui/state.py
@@ -96,33 +96,6 @@ class AppState:
                 return repo
         return None
 
-    def update_repository_command(self, repo_id: UUID, command: str | None) -> bool:
-        """Update a repository's custom Claude command.
-
-        Returns:
-            True if the repository was found and updated, False otherwise.
-        """
-        for repo in self._repositories:
-            if repo.id == repo_id:
-                repo.custom_claude_command = command
-                self._save_state()
-                return True
-        return False
-
-    def update_worktree_command(self, worktree_id: UUID, command: str | None) -> bool:
-        """Update a worktree's custom Claude command.
-
-        Returns:
-            True if the worktree was found and updated, False otherwise.
-        """
-        for repo in self._repositories:
-            for worktree in repo.worktrees:
-                if worktree.id == worktree_id:
-                    worktree.custom_claude_command = command
-                    self._save_state()
-                    return True
-        return False
-
     def find_worktree(self, worktree_id: UUID) -> tuple[Repository, Worktree] | None:
         """Find a worktree by ID and return with its parent repository."""
         for repo in self._repositories:

--- a/forestui/theme.py
+++ b/forestui/theme.py
@@ -255,9 +255,21 @@ ModalScreen {
     padding: 1 2;
 }
 
+.modal-container.modal-wide {
+    width: 140;
+    max-width: 95%;
+    height: 90%;
+}
+
 .modal-scroll {
+    width: 100%;
     height: auto;
     max-height: 20;
+}
+
+.modal-scroll.modal-scroll-tall {
+    height: 1fr;
+    max-height: 100vh;
 }
 
 .modal-title {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "humanize>=4.9.0",
     "libtmux>=0.37.0",
     "pydantic>=2.12.5",
-    "textual>=7.2.0",
+    "textual>=8.2.4",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ requires-dist = [
     { name = "humanize", specifier = ">=4.9.0" },
     { name = "libtmux", specifier = ">=0.37.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "textual", specifier = ">=7.2.0" },
+    { name = "textual", specifier = ">=8.2.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -702,7 +702,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "7.2.0"
+version = "8.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -712,9 +712,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/4b/24ae02d857ec0fa6661d27a989994e65c6a3b3d56c7177b2d8e022d29ccc/textual-7.2.0.tar.gz", hash = "sha256:5355f2dc16fbdc452a714dee2e440125e33b82373b3032cb53bea96e7019fa0b", size = 1582530, upload-time = "2026-01-11T17:40:50.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/b8/cc8ed2548ff1bf0fd719dd399bb56869d82a57143c2772cfd57f68efc1d3/textual-7.2.0-py3-none-any.whl", hash = "sha256:2624077f02dbd504beea9a24a943770f954f500a5f29a0bfa83465c52fa3ea1c", size = 715809, upload-time = "2026-01-11T17:40:48.679Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", size = 724390, upload-time = "2026-04-19T04:20:49.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Users can now configure arbitrary `New Session: X` buttons that spawn `claude` with any custom command. Each button has:

- A display **label** (e.g. `YoloDisc`)
- A **tmux window prefix** (auto-derived from the label, editable independently — so `YoloDisc` → `yolodisc:<repo>`)
- A **command** string that runs as-is when the button is pressed

Buttons whose command contains `--dangerously-skip-permissions` are auto-styled red like the existing YOLO button. Buttons render in the CLAUDE section (4-per-row wrapping) and as compact pills on each row of the recent-sessions list. The resume path reuses the custom command + prefix and appends `-r <session-id>`.

### Also in this PR

- **Removed:** the pre-existing per-repo/per-worktree/global `custom_claude_command` override. Custom buttons subsume that use case, and the feature was never used in practice.
- **Moved:** `Add Worktree` out of the CLAUDE section to sit next to `⟳ Git Pull` in the repo header, where a repo-scope action belongs.
- **Widened** the Settings + Manage modals (new `modal-wide` class) so they fill available vertical space — the `Manage Custom Buttons...` button is now always visible without scrolling on reasonably sized terminals.
- **Bumped** Textual to `>=8.2.4`.

## Test plan

- [x] `make check` (ruff + mypy + format) clean
- [x] Repo view: sidebar + detail pane, `[⟳ Git Pull][Add Worktree]` in header, CLAUDE row shows `[New Session][New Session: YOLO][YoloDisc][Opus]`, recent sessions card with `[Resume][YOLO][YoloDisc][Opus]`
- [x] Worktree view: `WORKTREE` header with Repository/Worktree/Branch/Based on, only `Git Pull` (no Add Worktree), same custom buttons
- [x] Settings modal fills available space at 221x60; `Manage Custom Buttons...` visible without scrolling
- [x] Manage modal: add, edit, delete, reorder (↑/↓), cancel correctly discards
- [x] YOLO-style auto-detection: buttons with `--dangerously-skip-permissions` render red
- [x] Live resize across 100x30 / 120x40 / 160x50 / 200x60 / 221x60 — all layouts adapt cleanly (requires `tu >=0.6.1` for testing in tu)