### PR TITLE
Fix crash when selecting a stale worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,8 @@ use the `test-forestui` skill to launch forestui in a headless terminal and
 visually verify the fix or feature works. Do this proactively, not only when
 asked.
 
-Currently no unit test suite. When adding tests:
-- Use pytest
-- Place tests in `tests/` directory
-- Add pytest to dev dependencies
+Unit tests live in `tests/` and run with `make test` (also part of `make check`).
+Use pytest; async code is driven with `asyncio.run()` inside sync tests.
 
 ## Versioning
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint typecheck format-check check format install dev clean
+.PHONY: lint typecheck format-check check test format install dev clean
 
 # Run ruff linter
 lint:
@@ -12,8 +12,12 @@ typecheck:
 format-check:
 	uv run ruff format --check forestui/
 
-# Run all checks (lint + typecheck + format)
-check: lint typecheck format-check
+# Run the test suite
+test:
+	uv run pytest tests/
+
+# Run all checks (lint + typecheck + format + tests)
+check: lint typecheck format-check test
 
 # Format code with ruff
 format:
@@ -42,7 +46,8 @@ help:
 	@echo "Available targets:"
 	@echo "  make lint      - Run ruff linter"
 	@echo "  make typecheck - Run mypy type checker"
-	@echo "  make check     - Run all checks (lint + typecheck)"
+	@echo "  make test      - Run the test suite"
+	@echo "  make check     - Run all checks (lint + typecheck + format + tests)"
 	@echo "  make format    - Format code with ruff"
 	@echo "  make install   - Install package locally"
 	@echo "  make dev       - Install with dev dependencies"

--- a/forestui/app.py
+++ b/forestui/app.py
@@ -261,6 +261,7 @@ class ForestApp(App[None]):
             result = self._state.find_worktree(selection.worktree_id)
             if result:
                 repo, worktree = result
+                path_exists = worktree.get_path().exists()
                 # Get commit info
                 commit_hash = ""
                 commit_time = None
@@ -284,6 +285,7 @@ class ForestApp(App[None]):
                         commit_time=commit_time,
                         has_remote=has_remote,
                         custom_buttons=self._settings_service.settings.custom_buttons,
+                        path_exists=path_exists,
                     )
                 )
                 # Fetch sessions in background

--- a/forestui/components/worktree_detail.py
+++ b/forestui/components/worktree_detail.py
@@ -81,6 +81,7 @@ class WorktreeDetail(Widget):
         commit_time: datetime | None = None,
         has_remote: bool = True,
         custom_buttons: list[CustomClaudeButton] | None = None,
+        path_exists: bool = True,
     ) -> None:
         super().__init__()
         self._repository = repository
@@ -88,6 +89,7 @@ class WorktreeDetail(Widget):
         self._commit_hash = commit_hash
         self._commit_time = commit_time
         self._has_remote = has_remote
+        self._path_exists = path_exists
         self._sessions: list[ClaudeSession] = []
         self._custom_buttons: list[CustomClaudeButton] = list(custom_buttons or [])
         self._buttons_by_prefix: dict[str, CustomClaudeButton] = {
@@ -112,6 +114,11 @@ class WorktreeDetail(Widget):
                     f"Branch:     {self._worktree.branch}",
                     classes="label-accent",
                 )
+                if not self._path_exists:
+                    yield Label(
+                        "⚠ MISSING:   directory no longer exists on disk",
+                        classes="label-destructive",
+                    )
                 # Base branch info (if available)
                 if self._worktree.base_branch:
                     base_text = f"Based on:   {self._worktree.base_branch}"
@@ -131,7 +138,14 @@ class WorktreeDetail(Widget):
                     yield Label(commit_text, classes="label-muted")
                 # Sync button
                 with Horizontal(classes="action-row"):
-                    if self._has_remote:
+                    if not self._path_exists:
+                        yield Button(
+                            "⟳ Git Pull (Directory missing)",
+                            id="btn-sync",
+                            variant="default",
+                            disabled=True,
+                        )
+                    elif self._has_remote:
                         yield Button("⟳ Git Pull", id="btn-sync", variant="default")
                     else:
                         yield Button(
@@ -145,10 +159,16 @@ class WorktreeDetail(Widget):
 
             # Location section
             yield Label("LOCATION", classes="section-header")
-            yield Label(
-                self._worktree.path,
-                classes="path-display label-secondary",
-            )
+            if self._path_exists:
+                yield Label(
+                    self._worktree.path,
+                    classes="path-display label-secondary",
+                )
+            else:
+                yield Label(
+                    f"{self._worktree.path}  (missing)",
+                    classes="path-display label-destructive",
+                )
 
             yield Rule()
 

--- a/forestui/services/git.py
+++ b/forestui/services/git.py
@@ -42,14 +42,22 @@ class GitService:
     async def _run_git(
         *args: str, cwd: str | Path | None = None
     ) -> tuple[int, str, str]:
-        """Run a git command and return exit code, stdout, stderr."""
+        """Run a git command and return exit code, stdout, stderr.
+
+        Raises GitError if the process cannot be spawned at all — most commonly
+        a stale worktree whose directory has been deleted, which makes `cwd`
+        invalid and raises FileNotFoundError.
+        """
         cmd = ["git", *args]
-        process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd) if cwd else None,
-        )
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(cwd) if cwd else None,
+            )
+        except OSError as e:
+            raise GitError(f"Failed to run git in {cwd}: {e}") from e
         stdout, stderr = await process.communicate()
         return (
             process.returncode or 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,15 @@ packages = ["forestui"]
 dev = [
     "mypy>=1.19.1",
     "pre-commit>=4.5.1",
+    "pytest>=8.4.2",
     "ruff>=0.14.11",
     "textual-dev>=1.7.0",
 ]
+
+[tool.pytest.ini_options]
+# libtmux ships a pytest plugin that is incompatible with pytest 8.x
+addopts = "-p no:libtmux"
+testpaths = ["tests"]
 
 [tool.mypy]
 python_version = "3.14"

--- a/tests/test_git_service.py
+++ b/tests/test_git_service.py
@@ -1,0 +1,18 @@
+"""Tests for GitService."""
+
+import asyncio
+
+import pytest
+
+from forestui.services.git import GitError, get_git_service
+
+
+def test_missing_cwd_raises_git_error() -> None:
+    """A stale worktree (deleted directory) must surface as GitError, not OSError."""
+    git = get_git_service()
+
+    with pytest.raises(GitError):
+        asyncio.run(git.get_latest_commit("/nonexistent/stale/worktree"))
+
+    with pytest.raises(GitError):
+        asyncio.run(git.has_remote_tracking("/nonexistent/stale/worktree"))

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "textual-dev" },
 ]
@@ -186,6 +187,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.14.11" },
     { name = "textual-dev", specifier = ">=1.7.0" },
 ]
@@ -256,6 +258,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -500,6 +511,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +535,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -633,6 +662,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Selecting a stale worktree in the sidebar — one whose directory has been deleted
outside forestui — crashes the app:

```
FileNotFoundError: [Errno 2] No such file or directory: '/…/gone-worktree'
```

And even without the crash, a stale worktree looked identical to a healthy one:
same header, a `Git Pull (No remote)` button, a normally-styled path. Nothing
told the user the directory was gone.

## Root cause

`GitService._run_git` passes the worktree path as the subprocess `cwd`. When that
directory no longer exists, `asyncio.create_subprocess_exec` raises
`FileNotFoundError` before git ever runs. Every call site only catches `GitError`
(e.g. `_refresh_detail_pane` around `get_latest_commit` / `has_remote_tracking`),
so the `OSError` escaped the handler and killed the app.

## Fix

**Crash:** wrap the spawn in `_run_git` and re-raise as `GitError`. One guard in
the shared helper covers every caller — commit info, remote tracking, pull,
branch listing, worktree listing — and also turns "git not on PATH" into a
handled error instead of a crash.

**Visibility:** `WorktreeDetail` now takes `path_exists`. When the directory is
missing it:

- shows a `⚠ MISSING: directory no longer exists on disk` line in the header
- marks the LOCATION path `(missing)` in the destructive color
- labels the disabled sync button `Git Pull (Directory missing)` rather than the
  misleading `(No remote)`

![Worktree detail for a deleted worktree directory](https://raw.githubusercontent.com/kirmalyshev/forestui/pr-assets/missing-worktree.png)

## Tests

This adds the first test to the repo:

- `tests/test_git_service.py` — asserts `GitError` (not `OSError`) for a missing path
- `pytest` dev dependency, `make test`, wired into `make check` (so CI runs it)
- `-p no:libtmux` in pytest config: libtmux's bundled pytest plugin is
  incompatible with pytest 8+ and errors at collection time

Verified end to end by driving the real app headless via `App.run_test()`:
selecting the stale worktree crashed before the change; afterwards it mounts
`WorktreeDetail` with the MISSING marker, and a healthy worktree renders exactly
as before. The new test fails on `main` and passes here.
