### PR TITLE
Fix PyPI publish: bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        # v1.14+ ships twine 7 / packaging 26, which understand the
+        # Metadata-Version 2.5 that hatchling >= 1.32 emits. v1.13 (twine 6)
+        # rejects it with "InvalidDistribution: '2.5' is not a valid metadata version".
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
The v1.3.1 release [failed to publish](https://github.com/flipbit03/forestui/actions/runs/31831218545):

```
Checking dist/forestui-1.3.1-py3-none-any.whl: ERROR InvalidDistribution:
Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Cause

`hatchling` 1.32.0 (released after v1.3.0 shipped in April) emits
`Metadata-Version: 2.5`. `pypa/gh-action-pypi-publish@v1.13.0` pins
`twine==6.1.0` / `packaging==25.0`, whose `_VALID_METADATA_VERSIONS` stops at
`2.4`, so `twine check` rejects our wheel before upload. Nothing to do with the
release contents — v1.3.0 built fine with the older hatchling.

## Fix

Bump the action to `v1.14.2`, which pins `twine==7.0.0` / `packaging==26.2`
(both understand 2.5). PyPI itself already accepts 2.5 uploads — hatchling
1.32.0's own wheel on PyPI carries `Metadata-Version: 2.5`.

## Verification

Reproduced locally against the real build output:

- `twine==6.1.0` + `packaging==25.0` → same `InvalidDistribution` error
- `twine==7.0.0` + `packaging==26.2` → `PASSED` for both wheel and sdist