### PR TITLE
Build the shipped configuration in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,3 +37,8 @@ jobs:
 
       - name: Run checks
         run: make check
+
+      # The release builds with `--features binary-release`; without this the
+      # configuration that ships is the only one never compiled in CI.
+      - name: Run checks for the shipped configuration
+        run: make check-shipped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,19 @@ make typecheck    # cargo check --all-targets
 make format-check # cargo fmt --check
 make test         # cargo test
 make check        # all of the above
+make check-shipped # lint + tests under --features binary-release
 make format       # cargo fmt
 make run          # cargo run
 make clean        # cargo clean
 ```
 
 Always run `make check` before committing changes.
+
+`make check-shipped` runs the same lint and tests with `--features binary-release`,
+which is the configuration the release workflow builds. The default build
+compiles strictly less code — the in-place updater is `#[cfg]`-ed out — so the
+two fail differently, and a mistake inside the feature-gated block is invisible
+to `make check`. CI runs both.
 
 ## Code Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint typecheck format-check check test format install dev run clean help
+.PHONY: lint typecheck format-check check check-shipped test format install dev run clean help
 
 # Run the linter
 lint:
@@ -18,6 +18,16 @@ test:
 
 # Run all checks (lint + typecheck + format + tests)
 check: format-check lint typecheck test
+
+# The configuration the release actually ships.
+#
+# `binary-release` gates the in-place updater, so the default build compiles a
+# strictly smaller amount of code: the download path is absent, and anything it
+# alone uses reads as dead. The two configurations therefore fail differently,
+# and the one that ships is the one `check` was not building.
+check-shipped:
+	cargo clippy --all-targets --features binary-release -- -D warnings
+	cargo test --features binary-release
 
 # Format code
 format:


### PR DESCRIPTION
The release workflow builds with `--features binary-release`. `check.yml` built only the default configuration, so the one users actually receive was the one never compiled in CI.

Not theoretical. The feature gates the in-place updater, so the default build compiles strictly less code — the block in `update_if_stale` that locates `current_exe()` and calls `install_from` is `#[cfg]`-ed out, and nothing in the test build reaches it either. I introduced a type error inside it and ran both:

```
make check           125 tests pass — sees nothing
make check-shipped   error[E0308]: mismatched types
```

Adds `make check-shipped` (clippy + tests under the feature) and runs it in CI after `make check`, on both runners. Kept as a separate target rather than folded into `check`, so the common local loop doesn't compile everything twice.

No functional change to forestui itself.