### PR TITLE
Apply the review pass: 15 defects in the hardening branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ interactions, or UI regressions. Use the `test-forestui` skill to drive forestui
 in a headless terminal with `tu` and verify the change works. Do this
 proactively, not only when asked.
 
-`doc/rust-rewrite/TU_USECASES.md` is the acceptance playbook: 94 numbered
+`doc/rust-rewrite/TU_USECASES.md` is the acceptance playbook: 96 numbered
 scenarios with exact keystrokes and expected output. The P0 cases are the
 regression suite — run the relevant ones after any behavioural change.
 

--- a/doc/rust-rewrite/MIGRATION.md
+++ b/doc/rust-rewrite/MIGRATION.md
@@ -6,7 +6,7 @@ Companion documents in this directory:
 |---|---|
 | `ARCHITECTURE.md` | Crate/module design, verified dependency versions, CSS→Layout mapping |
 | `SPEC.md` | Implementation-grade behavioural spec of the **Python** build (2 200+ lines, present and complete — sections 1–10) |
-| `TU_USECASES.md` | 52-case `tu` acceptance playbook, 25 of them P0 |
+| `TU_USECASES.md` | 96-case `tu` acceptance playbook, 52 of them P0 |
 | `MIGRATION.md` | This document: what actually changed, what is left, how to roll back |
 
 **Verification status of this document.** Every claim about the Rust side is derived from reading
@@ -16,6 +16,11 @@ found"), so nothing here has been compiled, tested, or run. Statements about com
 runtime behaviour, and render output are therefore *unverified by execution* and are flagged where
 they matter. The Python-side claims are backed by `SPEC.md` and by the 35 use cases in
 `TU_USECASES.md` that were driven live against Python `0.0.0`.
+
+> **Line references below point at `src/app.rs`, which no longer exists.** It was
+> split into `src/app/{mod,detail,keys,mouse,actions}.rs`; the code moved, the
+> behaviour described did not. Treat every `src/app.rs:NNN` in this document as
+> naming the behaviour, not a location.
 
 ---
 
@@ -139,17 +144,17 @@ modules are stubs totalling 18 lines.
 | `d` delete | Identical (message text differs — see 4.4) | `src/app.rs:631` |
 | `s` settings | Identical | `src/app.rs:632` |
 | `r` refresh sidebar + detail | Identical | `src/app.rs:635-638` ↔ `app.py:841-844` |
-| `?` help toast | Identical — string copied verbatim, still omits `o`, `y`, `r`, `?` | `src/app.rs:643-647` ↔ `app.py:848-851` |
+| `?` help toast | Fixed | Was a verbatim copy of Python's nine-key string, which omitted `o`, `y`, `r`, `A` and `?` itself. Now derived from `BINDINGS` + `EXTRA_BINDINGS`, so a reachable key cannot be undiscoverable (`src/app/keys.rs`) |
 | `A` toggle archived section | Fixed | New key; Python's `_show_archived` was initialised `False` and never set (`state.py:26`, UC-50). `src/app.rs:639-642` |
 | `Tab` switch sidebar ↔ detail | Changed | New concept; Textual had per-widget focus. `src/app.rs:579-585` |
 | `Up`/`Down` | Changed | Now context-dependent: sidebar cursor, detail cursor, or in-field cursor. `src/app.rs:586-604` |
 | `Enter` | Changed | Sidebar: re-select. Detail: fire `detail_items()[detail_index]`. `src/app.rs:605-617` |
 | `Ctrl+C` quit | Identical | `src/app.rs:560-563`; Textual bound it by default |
 | Hotkeys while a rename field has focus | Changed | Printable keys go to the field, so `q`/`a`/`d` no longer fire. Python's `q` was `priority=True` (`app.py:72`) and fired even inside an `Input`. `src/app.rs:571-576` |
-| Mouse click to select a row or press a button | Dropped | No mouse capture is enabled (`src/main.rs:50`); no `MouseEvent` arm in `handle_term_event` (`src/app.rs:545-553`) |
+| Mouse click to select a row or press a button | Supported | Was dropped in the first cut — no capture enabled, no `MouseEvent` arm. `main.rs::enable_mouse` now turns on `?1000h/?1002h/?1003h/?1006h`, and `src/app/mouse.rs` hit-tests clicks, hover, the wheel and the scrollbar against the regions each renderer records (UC-83–88, UC-90) |
 | Textual command palette (`ctrl+p`), built-in help panel | Dropped | Framework features with no ratatui equivalent |
-| `A` and `Tab` absent from the footer and from the `?` toast | Changed | `src/ui/mod.rs:56-69` lists 12 keys; `A` is not among them |
-| Footer key order | Changed | Rust: `q a w e t o n y h d s ?` (`src/ui/mod.rs:56-69`). Python rendered `a Add Repo  q Quit  w …` (UC-01 transcript) |
+| `A` and `Tab` absent from the footer | Changed | The footer draws the 12 entries of `BINDINGS`; `A` and `r` live in `EXTRA_BINDINGS`, which the `?` toast lists and the footer does not, matching Textual's footer width |
+| Footer key order | Identical | Both render `a q w e t o n y h d s ?`. Textual sorted `q` after `a` despite declaring it first, because it carried `priority=True`; the Rust `BINDINGS` table hardcodes that resolved order (`src/app/keys.rs`) |
 
 ### 4.2 Startup, CLI, tmux entry
 

--- a/doc/rust-rewrite/TU_USECASES.md
+++ b/doc/rust-rewrite/TU_USECASES.md
@@ -438,9 +438,13 @@ enabled for a repo with no remote.
 1. `tu screenshot --name fui --png -o /tmp/uc13.png`; `Read` it.
 
 **Expected:** the button reads exactly `↓ Git Pull (No remote)` and is rendered
-disabled (dimmed, not focusable).
-**Fails if:** the button says `↓ Git Pull` and is clickable — pulling a repo with no
-upstream errors out and the app would surface a raw git error.
+disabled (dimmed). It *keeps its slot in the focus ring* — a disabled control
+still occupies its index, so the items either side of it do not shift — and is
+inert: neither Enter nor a click runs it.
+**Fails if:** the button says `↓ Git Pull`, or it fires when activated —
+pulling a repo with no upstream errors out and the app would surface a raw git
+error. Earlier revisions of this case said "not focusable"; the build has never
+done that, and skipping disabled items would move every index behind them.
 
 ---
 
@@ -1307,9 +1311,15 @@ wording in both builds. Nothing is deleted yet.
 
 ### UC-59 — `?` shows the help toast
 **Area:** Sweep | **Priority:** P1 | 🟢 EXECUTED (both builds)
-**Expected:** `a: Add Repo | w: Add Worktree | e: Editor | t: Terminal | n: Claude
-| h: Archive | d: Delete | s: Settings | q: Quit`.
-**Known gap in both:** the toast omits `o`, `y`, `r` and `?` itself.
+**Expected (Rust):** every binding the app has, in footer order, wrapped over
+as many lines as it needs: `a: Add Repo | q: Quit | w: Add Worktree | e: Editor
+| t: Terminal | o: Files | n: Claude | y: ClaudeYOLO | h: Archive | d: Delete |
+s: Settings | ?: Help | r: Refresh | A: Show Archived`. It is derived from the
+same `BINDINGS` table that draws the footer, plus `EXTRA_BINDINGS` for the two
+keys that never fit it, so a key cannot be reachable yet undiscoverable.
+**Divergence from Python:** the Textual build hardcoded a nine-key string and
+omitted `o`, `y`, `r`, `A` and `?` itself. The Rust toast is deliberately
+longer; `baseline/python/UC-59-help-notification.txt` still shows the short one.
 
 ### UC-60 — `e` opens the editor window
 **Area:** Sweep | **Priority:** P0 | 🟢 EXECUTED (both builds)
@@ -1506,9 +1516,11 @@ depending on which pane has focus.
 
 ### UC-89 — Controls render as buttons
 **Area:** Visual | **Priority:** P1 | 🟢 EXECUTED (Rust)
-**Expected:** every control renders as a filled pill (`▐ Label ▏`), visibly a
-button rather than plain text, with the focused one highlighted and destructive
-ones red.
+**Expected:** every control renders as a three-row bordered box
+(`┌────────┐` / `│ Editor │` / `└────────┘`), visibly a button rather than plain
+text, with the focused one highlighted and destructive ones red. An earlier cut
+drew filled pills (`▐ Label ▏`); the boxes are what matches Textual's
+`Button { border: solid; height: 3 }` and what every committed baseline shows.
 **Fails if:** controls read as flat labels — a user reported exactly that.
 
 ---
@@ -1562,6 +1574,27 @@ session and each GitHub issue, and the LOCATION path in a bordered box. Without
 them the pane reads as one flat undifferentiated list, which is what a user
 comparing the two builds side by side noticed first.
 
+### UC-95 — The fixture exercises every section it claims to compare
+**Area:** Harness | **Priority:** P0 | 🟢 EXECUTED (both builds)
+**Steps:** part of `scripts/tu-sweep.sh`; the throwaway forest is seeded with
+Claude session files and a stubbed `gh` before the app is launched.
+**Expected:** the sweep's repository pane shows real sessions and real issues,
+not the empty state. A sweep that never renders a section reports parity for it
+regardless of what the two builds would have drawn there.
+**Fails if:** any section falls back to `No sessions found`, `No issues found`
+or `No repositories`. The session cards went uncompared that way for days, and
+the issue rows right behind them.
+
+### UC-96 — The comparison frame is tall enough to hold the pane
+**Area:** Harness | **Priority:** P0 | 🟢 EXECUTED (both builds)
+**Steps:** `tu resize --name <session> 140x140`, then capture.
+**Expected:** the whole repository pane is inside one frame — `msgs` from a
+session card and the `#326`/`#298` issue rows all present — so the diff covers
+it. At the sweep's normal 140x44 the sections below the fold are absent from
+the frame and therefore absent from the comparison.
+**Fails if:** the tall capture is missing either marker, which means the frame
+being diffed stops short of the content the case exists to compare.
+
 ---
 
 ## Known visual divergences (accepted, not defects)
@@ -1606,7 +1639,7 @@ composite shows a difference not listed above, treat it as a regression.
 | Flows & mouse | 78–89 | 8 |
 | Visual parity | 90–94 | 1 |
 
-**94 use cases · 50 P0 · 76 executed live · 17 written from source only.**
+**96 use cases · 52 P0 · 78 executed live · 17 written from source only.**
 
 UC-01–52 were written against the Python build on 2026-08-14 (35 executed).
 UC-53–70 are the automated sweep and have been executed against **both** builds;

--- a/scripts/tu-sweep.sh
+++ b/scripts/tu-sweep.sh
@@ -161,7 +161,19 @@ focus_app() { press Ctrl+B 0; sleep 0.7; }
 # Wait until the screen shows <regex>, rather than sleeping a fixed amount.
 # Textual repaints noticeably slower than ratatui, so a fixed sleep captures the
 # two builds at different points in the same interaction.
-await() { tu wait --name "$SESS" --text "$1" --timeout "${2:-12000}" >/dev/null 2>&1; }
+# await <regex> [timeout-ms] — block until the screen shows something.
+#
+# A timeout is reported rather than swallowed. It used to return quietly and
+# the caller captured anyway, so a case that never reached its state still
+# wrote a frame — and that frame diffed clean against a baseline captured the
+# same way, which is a green test for a screen nobody ever saw.
+await() {
+  if ! tu wait --name "$SESS" --text "$1" --timeout "${2:-12000}" >/dev/null 2>&1; then
+    printf '  WAIT-TIMEOUT  %s\n' "$1" >&2
+    WAIT_TIMEOUTS=$((WAIT_TIMEOUTS + 1))
+  fi
+}
+WAIT_TIMEOUTS=0
 
 # capture <UC-ID> <slug> [session] — one PNG plus one normalised text frame.
 #
@@ -310,7 +322,10 @@ done
 
 # Editor reuses its window; terminal always opens a new, uniquified one.
 focus_app; press e
-await "edit:alpha"; sleep 1.0
+# Nothing new appears — that is the whole point of the case — so there is no
+# screen condition to wait on. `await "edit:alpha"` looked like one but matched
+# the status bar UC-60 already left behind.
+sleep 1.5
 capture UC-65 window-editor-reused
 focus_app; press t
 await "term:alpha:wt-a:2"; sleep 1.0
@@ -319,10 +334,10 @@ capture UC-66 window-terminal-uniquified
 focus_app; press A; sleep 1.2
 capture UC-67 archived-section-toggle
 focus_app; press h
-await "Unarchive"; sleep 0.8
+await "│ Unarchive │"; sleep 0.8
 capture UC-68 worktree-archived
 focus_app; press h
-await "[^n]Archive"; sleep 0.8
+await "│ Archive │"; sleep 0.8
 capture UC-69 worktree-unarchived
 
 focus_app; press r; sleep 1.5
@@ -535,5 +550,10 @@ capture UC-86 click-modal-cancel
 assert UC-86 modal-dismissed-by-click "no" "$(screen_has 'Repository Path')"
 
 echo "done: $LABEL"
+if [ "$WAIT_TIMEOUTS" -gt 0 ]; then
+  # Loud on purpose: every timed-out wait captured a frame of whatever was on
+  # screen instead, so the frames below are not all what they claim to be.
+  echo "WARNING: $WAIT_TIMEOUTS wait(s) timed out — those captures are suspect"
+fi
 echo "assertions:"
 sed 's/^/  /' "$ASSERTIONS"

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 /// refetch-after-fetch inside it — what a branch load returns must not depend
 /// on which of the two paths asked for it.
 async fn load_branches(tx: EventTx, path: String, repo_id: Uuid, target: BranchTarget) {
-    let branches = git::list_branches(&path, true).await.unwrap_or_default();
+    let branches = git::list_branches(&path).await.unwrap_or_default();
     let remotes = git::list_remotes(&path).await.unwrap_or_default();
     let current_branch = git::get_current_branch(&path)
         .await
@@ -171,10 +171,7 @@ impl App {
                     ))));
             }
             BranchTarget::CreateFromIssue => {
-                let Some(index) = self.pending_issue.take() else {
-                    return;
-                };
-                let Some(issue) = self.issues.as_ref().and_then(|i| i.get(index)).cloned() else {
+                let Some(issue) = self.pending_issue.take() else {
                     return;
                 };
                 let Some(repo) = self.state.find_repository(repo_id) else {
@@ -322,8 +319,16 @@ impl App {
                 self.fetch_issues();
             }
             Action::CreateFromIssue(index) => {
-                if let Some(repo_id) = self.state.selection.repository_id {
-                    self.pending_issue = Some(index);
+                // The issue is captured here rather than looked up again when
+                // the branches land: `issues` is replaced wholesale by every
+                // refresh and by selecting another repository, so an index held
+                // across the branch load could resolve to a different issue —
+                // or to another repository's issue entirely, which then built a
+                // worktree in the wrong repository.
+                if let Some(repo_id) = self.state.selection.repository_id
+                    && let Some(issue) = self.issues.as_ref().and_then(|i| i.get(index)).cloned()
+                {
+                    self.pending_issue = Some(issue);
                     self.load_branches_then(repo_id, BranchTarget::CreateFromIssue);
                 }
             }
@@ -500,13 +505,16 @@ impl App {
                 let requested = new_branch.clone();
                 tokio::spawn(async move {
                     match git::rename_branch(&worktree_path, &old_branch, &requested).await {
-                        Ok(()) => tx.send(AppEvent::ReloadDetail),
+                        // Folded on success only. Writing the name up front left
+                        // the config — and the sidebar — permanently showing a
+                        // branch git had refused to create.
+                        Ok(()) => tx.send(AppEvent::WorktreeBranchRenamed {
+                            worktree_id,
+                            branch: requested,
+                        }),
                         Err(error) => tx.error(format!("Branch rename failed: {error}")),
                     }
                 });
-                self.state
-                    .update_worktree(worktree_id, |w| w.branch = new_branch.clone());
-                self.rebuild_rows();
             }
         }
     }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -125,7 +125,21 @@ impl App {
             _ => {}
         }
 
-        match key.code {
+        if let KeyCode::Char(binding) = key.code {
+            self.run_binding(binding);
+        }
+    }
+
+    /// Run a footer binding by its character.
+    ///
+    /// Split out because clicking the footer is not the same as typing: the
+    /// click already says which binding was meant, so it must not be re-routed
+    /// into a focused rename field, where `d Delete` would have been typed into
+    /// the name instead of deleting anything.
+    pub(super) fn run_binding(&mut self, binding: char) {
+        use ratatui::crossterm::event::KeyCode;
+
+        match KeyCode::Char(binding) {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Char('a') => self
                 .modals

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -494,6 +494,22 @@ impl App {
         }
     }
 
+    /// Announce a state change that has just been persisted — unless it wasn't.
+    ///
+    /// The success toast is only true if the config write landed. A dropped
+    /// write is silent otherwise, and the config deliberately loads as empty
+    /// state, so the user would be told a worktree exists that vanishes on the
+    /// next launch.
+    pub fn notify_saved(&mut self, text: impl Into<String>) {
+        match self.state.take_save_error() {
+            Some(error) => self.notify(
+                format!("Could not save the config: {error}"),
+                Severity::Error,
+            ),
+            None => self.notify(text, Severity::Information),
+        }
+    }
+
     fn expire_notifications(&mut self) {
         self.notifications
             .retain(|n| n.created.elapsed() < NOTIFICATION_TTL);
@@ -617,8 +633,9 @@ impl App {
                 self.reload_detail();
                 // Announced here rather than from the task, so a result that
                 // was dropped above never produces a success toast for a
-                // worktree that is not in the config.
-                self.notify(format!("Created worktree '{name}'"), Severity::Information);
+                // worktree that is not in the config — and `notify_saved`
+                // extends that to a write that was attempted and failed.
+                self.notify_saved(format!("Created worktree '{name}'"));
             }
             AppEvent::WorktreesImported { repo_id, worktrees } => {
                 if self.state.find_repository(repo_id).is_none() {
@@ -626,11 +643,15 @@ impl App {
                 }
                 let count = worktrees.len();
                 self.state.add_worktrees(repo_id, worktrees);
-                self.state.select_repository(repo_id);
+                // Imported worktrees are new *sidebar rows*; no detail pane
+                // shows them. Selecting the repository and reloading its pane
+                // only ever moved someone who had navigated on while the
+                // `git worktree list` ran, throwing away the sessions and
+                // issues they were reading. The add-repository flow that starts
+                // this import has already selected the repository itself.
                 self.rebuild_rows();
                 self.sync_sidebar_index();
-                self.reload_detail();
-                self.notify(format!("Imported {count} worktrees"), Severity::Information);
+                self.notify_saved(format!("Imported {count} worktrees"));
             }
             AppEvent::WorktreeRenamed {
                 worktree_id,
@@ -641,6 +662,12 @@ impl App {
                     worktree.name = name;
                     worktree.path = path;
                 });
+                // The rename fields are only re-seeded when the *target*
+                // changes, so without this they keep whatever the pane last
+                // showed — the pre-rename name, if the user navigated away and
+                // back while the task ran. Pressing Enter would then rename the
+                // worktree straight back.
+                self.rename_target = None;
                 self.rebuild_rows();
                 self.sync_sidebar_index();
                 self.reload_detail();
@@ -854,6 +881,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_completed_rename_resyncs_the_field_it_renamed() {
+        let (_dir, mut app) = app_with_fixture();
+        // Select the first worktree, which seeds the rename fields from it.
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("a worktree");
+        let old_name = app.name_input.value().to_string();
+
+        // The rename runs off the event loop now, and the user is free to move
+        // around while it does. Coming back re-seeds the field from the state
+        // as it still is — the old name.
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.name_input.value(), old_name);
+
+        // Now the task lands.
+        app.handle_event(AppEvent::WorktreeRenamed {
+            worktree_id,
+            name: "renamed".into(),
+            path: "/tmp/renamed".into(),
+        });
+
+        assert_eq!(
+            app.name_input.value(),
+            "renamed",
+            "the field still holds the pre-rename name; pressing Enter would rename it back"
+        );
+    }
+
+    #[tokio::test]
     async fn quit_and_help_hotkeys() {
         let (_dir, mut app) = app_with_fixture();
         app.handle_key(key(KeyCode::Char('?')));
@@ -943,6 +999,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn a_worktree_that_could_not_be_saved_is_not_announced_as_created() {
+        let (dir, mut app) = app_with_fixture();
+        let repo_id = app.state.repositories()[0].id;
+
+        // Make the config unwritable: the directory holding it denies writes, so
+        // the atomic write cannot even stage its temp file.
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+
+        let worktree = Worktree::new("doomed".into(), "feat/doomed".into(), "/tmp/doomed".into());
+        app.handle_event(AppEvent::WorktreeAdded {
+            repo_id,
+            worktree: Box::new(worktree),
+        });
+
+        let last = app.notifications.last().expect("a toast");
+        assert_eq!(
+            last.severity,
+            Severity::Error,
+            "a failed write was announced as a success: {}",
+            last.text
+        );
+        assert!(
+            last.text.starts_with("Could not save the config"),
+            "unexpected toast: {}",
+            last.text
+        );
+
+        // Let the tempdir clean itself up.
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+    }
+
     /// If the repository is removed while git runs, the late result is dropped
     /// rather than resurrected as an entry nothing owns.
     #[tokio::test]
@@ -965,7 +1058,7 @@ mod tests {
     /// and leaves the repository selected.
     #[tokio::test]
     async fn imported_worktrees_are_folded_into_state() {
-        let (_dir, mut app) = app_with_fixture();
+        let (dir, mut app) = app_with_fixture();
         let repo_id = app.state.repositories()[0].id;
         let before = app.state.repositories()[0].worktrees.len();
 
@@ -980,6 +1073,52 @@ mod tests {
         assert_eq!(app.state.repositories()[0].worktrees.len(), before + 2);
         assert_eq!(app.state.selection.repository_id, Some(repo_id));
         assert_eq!(app.state.selection.worktree_id, None);
+
+        // In memory is not enough: an import that never reaches the config is
+        // gone on the next launch, and the fold is the only writer.
+        let reloaded = AppState::load_from(dir.path().join(".forestui-config.json"));
+        assert_eq!(
+            reloaded.repositories()[0].worktrees.len(),
+            before + 2,
+            "the import was never persisted"
+        );
+
+        // A result for a repository that has since been removed is dropped.
+        app.handle_event(AppEvent::WorktreesImported {
+            repo_id: Uuid::new_v4(),
+            worktrees: vec![Worktree::new(
+                "ghost".into(),
+                "main".into(),
+                "/tmp/g".into(),
+            )],
+        });
+        assert_eq!(app.state.repositories()[0].worktrees.len(), before + 2);
+    }
+
+    #[tokio::test]
+    async fn an_import_that_lands_late_does_not_steal_the_selection() {
+        let (_dir, mut app) = app_with_fixture();
+        let repo_id = app.state.repositories()[0].id;
+
+        // The user moved on to a worktree while the import was still running.
+        app.handle_key(key(KeyCode::Down));
+        let selected = app.state.selection.worktree_id.expect("a worktree");
+        app.sessions = Some(Vec::new());
+
+        app.handle_event(AppEvent::WorktreesImported {
+            repo_id,
+            worktrees: vec![Worktree::new("i1".into(), "main".into(), "/tmp/i1".into())],
+        });
+
+        assert_eq!(
+            app.state.selection.worktree_id,
+            Some(selected),
+            "the import yanked the cursor back to the repository"
+        );
+        assert!(
+            app.sessions.is_some(),
+            "the pane the user was reading was reloaded out from under them"
+        );
     }
 
     #[tokio::test]
@@ -1047,6 +1186,48 @@ mod tests {
         );
         assert_eq!(app.hit_at(50, 0), None, "outside every region");
         assert_eq!(app.hit_at(5, 9), None, "wrong row");
+    }
+
+    fn wheel(column: u16, row: u16) -> ratatui::crossterm::event::MouseEvent {
+        use ratatui::crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+        MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_toast_swallows_the_clicks_it_covers() {
+        let (_dir, mut app) = app_with_fixture();
+        // A control is recorded first, then a toast is drawn over the same cell.
+        app.push_hit(rect(10, 5, 20, 3), HitTarget::DetailItem(0));
+        app.push_hit(rect(10, 5, 20, 3), HitTarget::Notification);
+
+        assert_eq!(
+            app.hit_at(12, 6),
+            Some(HitTarget::Notification),
+            "the toast must win the cells it covers, or the control under it runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_open_modal_owns_the_wheel_as_well_as_the_click() {
+        let (_dir, mut app) = app_with_fixture();
+        app.sidebar_rect = rect(0, 0, 30, 20);
+        let before = app.state.selection;
+
+        // The panes are still drawn behind a modal, so they are still
+        // hit-testable; only the guard stops the wheel reaching them.
+        app.handle_key(key(KeyCode::Char('s')));
+        assert_eq!(app.modals.len(), 1);
+        app.handle_mouse(wheel(4, 5));
+
+        assert_eq!(
+            app.state.selection, before,
+            "the wheel reselected the sidebar behind an open modal"
+        );
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -171,7 +171,8 @@ pub struct App {
     /// Worktree the rename inputs belong to, so a selection change resets them.
     pub(crate) rename_target: Option<Uuid>,
     /// Issue whose modal is waiting on a branch list to finish loading.
-    pub(crate) pending_issue: Option<usize>,
+    /// The issue a Create-WT click captured, held across the branch load.
+    pub(crate) pending_issue: Option<crate::models::GitHubIssue>,
 }
 
 impl App {
@@ -398,6 +399,8 @@ impl App {
         // control from the previous pane against the new selection would act
         // on the wrong thing entirely.
         self.drawn_items.clear();
+        // A create-from-issue flow belongs to the selection that started it.
+        self.pending_issue = None;
 
         let Some(path) = self.state.selected_path() else {
             self.meta = DetailMeta::default();
@@ -507,6 +510,16 @@ impl App {
                 Severity::Error,
             ),
             None => self.notify(text, Severity::Information),
+        }
+    }
+
+    /// Report a failed write for a change that announces nothing when it works.
+    fn report_save_error(&mut self) {
+        if let Some(error) = self.state.take_save_error() {
+            self.notify(
+                format!("Could not save the config: {error}"),
+                Severity::Error,
+            );
         }
     }
 
@@ -671,6 +684,19 @@ impl App {
                 self.rebuild_rows();
                 self.sync_sidebar_index();
                 self.reload_detail();
+                self.report_save_error();
+            }
+            AppEvent::WorktreeBranchRenamed {
+                worktree_id,
+                branch,
+            } => {
+                self.state
+                    .update_worktree(worktree_id, |worktree| worktree.branch = branch);
+                self.rename_target = None;
+                self.rebuild_rows();
+                self.sync_sidebar_index();
+                self.reload_detail();
+                self.report_save_error();
             }
             AppEvent::ReloadDetail => self.reload_detail(),
         }
@@ -1095,6 +1121,53 @@ mod tests {
         assert_eq!(app.state.repositories()[0].worktrees.len(), before + 2);
     }
 
+    /// A branch rename that git refuses must leave no trace. The name used to
+    /// be written and persisted before `git branch -m` ran, so a collision left
+    /// the config and the sidebar naming a branch that does not exist.
+    #[tokio::test]
+    async fn a_branch_rename_lands_only_when_git_agrees() {
+        let (dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("a worktree");
+        let original = app
+            .state
+            .find_worktree(worktree_id)
+            .map(|(_, w)| w.branch.clone())
+            .expect("a branch");
+
+        // What the failing path does: report, and fold nothing.
+        app.handle_event(AppEvent::Notify(
+            "Branch rename failed: already exists".into(),
+            Severity::Error,
+        ));
+        assert_eq!(
+            app.state.find_worktree(worktree_id).map(|(_, w)| &w.branch),
+            Some(&original),
+            "the branch was renamed in state before git ran"
+        );
+
+        // And the success path folds through the event.
+        app.handle_event(AppEvent::WorktreeBranchRenamed {
+            worktree_id,
+            branch: "feat/accepted".into(),
+        });
+        assert_eq!(
+            app.state
+                .find_worktree(worktree_id)
+                .map(|(_, w)| w.branch.as_str()),
+            Some("feat/accepted")
+        );
+        let reloaded = AppState::load_from(dir.path().join(".forestui-config.json"));
+        assert!(
+            reloaded
+                .repositories()
+                .iter()
+                .flat_map(|r| &r.worktrees)
+                .any(|w| w.branch == "feat/accepted"),
+            "the accepted rename was never persisted"
+        );
+    }
+
     #[tokio::test]
     async fn an_import_that_lands_late_does_not_steal_the_selection() {
         let (_dir, mut app) = app_with_fixture();
@@ -1196,6 +1269,35 @@ mod tests {
             row,
             modifiers: KeyModifiers::NONE,
         }
+    }
+
+    /// The footer is a row of buttons, and a click on one says which binding
+    /// was meant. Replaying it as a keystroke let a focused rename field eat it
+    /// as text — every footer button was dead while renaming.
+    #[tokio::test]
+    async fn a_footer_click_works_while_a_rename_field_has_focus() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        app.sessions = Some(Vec::new());
+        snapshot_drawn(&mut app);
+
+        app.focus = Focus::Detail;
+        app.detail_index = app
+            .detail_items()
+            .iter()
+            .position(|item| *item == DetailItem::Field(Field::WorktreeName))
+            .expect("rename field present");
+        let name = app.name_input.value().to_string();
+
+        app.push_hit(rect(0, 40, 10, 1), HitTarget::FooterKey('s'));
+        app.handle_mouse(click(2, 40));
+
+        assert_eq!(app.modals.len(), 1, "the settings dialog never opened");
+        assert_eq!(
+            app.name_input.value(),
+            name,
+            "the click was typed into the rename field"
+        );
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ mod mouse;
 
 pub use detail::{Action, DetailItem, Field};
 pub use keys::BINDINGS;
-pub use mouse::{Hit, HitTarget, ModalClick, ScrollbarGeom};
+pub use mouse::{Direction, Hit, HitTarget, ModalClick, ScrollbarGeom};
 
 use crate::event::{AppEvent, DetailMeta, EventTx, Severity};
 use crate::modal::Modal;
@@ -1426,13 +1426,33 @@ mod tests {
             rect(0, 5, 20, 1),
             HitTarget::ModalControl {
                 index: 0,
-                click: ModalClick::Cycle,
+                click: ModalClick::Cycle(Direction::Next),
             },
         );
         app.handle_mouse(click(3, 5));
         assert_eq!(app.modals.len(), 1, "clicking a cycle closed the dialog");
+        let advanced = match app.modals.last() {
+            Some(Modal::Settings(m)) => {
+                assert_ne!(m.editor_index, before, "cycle did not advance");
+                m.editor_index
+            }
+            _ => panic!("settings modal expected"),
+        };
+
+        // `◂` is the other direction, not a second `▸`.
+        app.push_hit(
+            rect(0, 5, 20, 1),
+            HitTarget::ModalControl {
+                index: 0,
+                click: ModalClick::Cycle(Direction::Previous),
+            },
+        );
+        app.handle_mouse(click(3, 5));
         match app.modals.last() {
-            Some(Modal::Settings(m)) => assert_ne!(m.editor_index, before, "cycle did not advance"),
+            Some(Modal::Settings(m)) => assert_ne!(
+                m.editor_index, advanced,
+                "the left arrow advanced the value instead of stepping back"
+            ),
             _ => panic!("settings modal expected"),
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1541,7 +1541,8 @@ mod tests {
             _ => panic!("settings modal expected"),
         };
 
-        // `◂` is the other direction, not a second `▸`.
+        // `Previous` steps back to exactly where it started — not merely
+        // "somewhere else", which a second forward step would also satisfy.
         app.push_hit(
             rect(0, 5, 20, 1),
             HitTarget::ModalControl {
@@ -1551,9 +1552,10 @@ mod tests {
         );
         app.handle_mouse(click(3, 5));
         match app.modals.last() {
-            Some(Modal::Settings(m)) => assert_ne!(
-                m.editor_index, advanced,
-                "the left arrow advanced the value instead of stepping back"
+            Some(Modal::Settings(m)) => assert_eq!(
+                m.editor_index, before,
+                "stepping back from {advanced} landed on {} instead of {before}",
+                m.editor_index
             ),
             _ => panic!("settings modal expected"),
         }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -100,10 +100,19 @@ pub enum ModalClick {
     Activate,
     /// Text inputs: focus only.
     Focus,
-    /// A `◂ value ▸` cycle: focus, then advance one step.
-    Cycle,
+    /// A `◂ value ▸` cycle: focus, then step one value in `Direction`. The
+    /// glyphs stand for Left and Right, so a click on `◂` has to go back —
+    /// sending Right for both made the left arrow a second right arrow.
+    Cycle(Direction),
     /// A row of a list: focus the list and select that row.
     Row(usize),
+}
+
+/// Which way a [`ModalClick::Cycle`] steps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Previous,
+    Next,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -398,7 +407,8 @@ impl App {
         }
         match click {
             ModalClick::Activate => self.send_modal_key(KeyCode::Enter),
-            ModalClick::Cycle => self.send_modal_key(KeyCode::Right),
+            ModalClick::Cycle(Direction::Next) => self.send_modal_key(KeyCode::Right),
+            ModalClick::Cycle(Direction::Previous) => self.send_modal_key(KeyCode::Left),
             // Focusing a field must not submit the dialog, and selecting a row
             // is already done above.
             ModalClick::Focus | ModalClick::Row(_) => {}

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -271,10 +271,10 @@ impl App {
                 }
             }
             HitTarget::FooterKey(key) => {
-                self.handle_key(ratatui::crossterm::event::KeyEvent::new(
-                    ratatui::crossterm::event::KeyCode::Char(key),
-                    ratatui::crossterm::event::KeyModifiers::NONE,
-                ));
+                // Run the binding directly rather than replaying a keystroke: a
+                // focused rename field owns every printable key, so a replayed
+                // click on `d Delete` was typed into the worktree name instead.
+                self.run_binding(key);
             }
             HitTarget::ModalControl { .. } => {}
         }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -121,6 +121,12 @@ pub enum HitTarget {
         index: usize,
         click: ModalClick,
     },
+    /// A notification toast. It does nothing when clicked, but it has to claim
+    /// its cells: it is drawn *over* the detail pane, and without a region of
+    /// its own the click lands on whichever control it covers — which is how a
+    /// click on the toast could start a `--dangerously-skip-permissions`
+    /// session from the card underneath.
+    Notification,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -156,13 +162,26 @@ impl App {
     pub fn handle_mouse(&mut self, mouse: ratatui::crossterm::event::MouseEvent) {
         use ratatui::crossterm::event::{MouseButton, MouseEventKind};
 
+        // A modal owns the pointer, not just the click. The panes behind it are
+        // still drawn — and so still hit-testable — so without this the wheel
+        // scrolls, and reselects, the sidebar underneath an open dialog, and a
+        // dialog wide enough to cover the scrollbar track hands its presses to
+        // the bar instead of to the control the user aimed at. Hover is
+        // deliberately exempt: the hit list carries the modal's own controls,
+        // and lighting them up is the point.
+        let modal_open = !self.modals.is_empty();
+
         match mouse.kind {
             MouseEventKind::ScrollDown => {
-                self.scroll_at(mouse.column, mouse.row, 1);
+                if !modal_open {
+                    self.scroll_at(mouse.column, mouse.row, 1);
+                }
                 return;
             }
             MouseEventKind::ScrollUp => {
-                self.scroll_at(mouse.column, mouse.row, -1);
+                if !modal_open {
+                    self.scroll_at(mouse.column, mouse.row, -1);
+                }
                 return;
             }
             // Hover. The pointer crossing cells inside one control changes
@@ -179,7 +198,9 @@ impl App {
             // mid-drag, so this is not gated on where it currently is — only on
             // a drag having started there.
             MouseEventKind::Drag(MouseButton::Left) => {
-                self.drag_scrollbar(mouse.row);
+                if !modal_open {
+                    self.drag_scrollbar(mouse.row);
+                }
                 return;
             }
             // The release carries a position too, and it is often past the last
@@ -187,12 +208,14 @@ impl App {
             // rows beyond where the last motion landed. Applying it before
             // letting go means the thumb finishes where the pointer did.
             MouseEventKind::Up(MouseButton::Left) => {
-                self.drag_scrollbar(mouse.row);
+                if !modal_open {
+                    self.drag_scrollbar(mouse.row);
+                }
                 self.scroll_drag = None;
                 return;
             }
             MouseEventKind::Down(MouseButton::Left) => {
-                if self.grab_scrollbar(mouse.column, mouse.row) {
+                if !modal_open && self.grab_scrollbar(mouse.column, mouse.row) {
                     return;
                 }
             }
@@ -219,6 +242,9 @@ impl App {
                 self.select_current_row();
             }
             HitTarget::SidebarToggle(index) => self.toggle_collapsed(index),
+            // Swallowed on purpose: the toast has no action, and the whole
+            // point of recording it is that the control beneath does not run.
+            HitTarget::Notification => {}
             HitTarget::DetailItem(index) => {
                 self.focus = Focus::Detail;
                 self.detail_index = index;
@@ -301,10 +327,16 @@ impl App {
     /// aiming at it, and stealing focus here would move the keyboard cursor into
     /// the pane every time the user only wanted to read further down.
     fn grab_scrollbar(&mut self, column: u16, row: u16) -> bool {
+        // A press that is not on the track ends any grab the last gesture left
+        // behind. Releases can go missing — the pointer leaving the terminal
+        // mid-drag is enough — and a stale offset would make the next drag
+        // anywhere in the pane scroll it with no bar held.
         let Some(geom) = self.scrollbar else {
+            self.scroll_drag = None;
             return false;
         };
         if !contains(geom.track, column, row) {
+            self.scroll_drag = None;
             return false;
         }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -95,6 +95,10 @@ pub enum AppEvent {
         name: String,
         path: String,
     },
+    /// A worktree's branch was renamed by git. Folded only on success: the
+    /// config used to take the new name before `git branch -m` ran and keep it
+    /// when the rename failed, leaving a branch recorded that does not exist.
+    WorktreeBranchRenamed { worktree_id: Uuid, branch: String },
     /// Reload the detail pane only.
     ReloadDetail,
 }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -148,6 +148,13 @@ impl Modal {
                 let count = m.matches().len();
                 if count > 0 {
                     m.search_index = row.min(count - 1);
+                    // Picking a row commits it, the way Enter does from the
+                    // keyboard. Only `search` is read by `selected_branch` and
+                    // `can_create`, so highlighting alone left Create disabled
+                    // and a mouse-only user with no way to choose a branch.
+                    if let Some((branch, _)) = m.matches().into_iter().nth(m.search_index) {
+                        m.search.set_value(branch);
+                    }
                 }
             }
             Modal::CustomButtons(m) if !m.buttons.is_empty() => {
@@ -1241,6 +1248,37 @@ mod tests {
             modal.handle_key(key(KeyCode::Enter)),
             ModalOutcome::Submit(ModalResult::WorktreeCreated { .. })
         ));
+    }
+
+    /// Clicking a branch row has to *pick* the branch, not just light it up:
+    /// `can_create` reads `search`, so a mouse-only user was left with Create
+    /// permanently disabled and no way to choose.
+    #[test]
+    fn clicking_a_branch_row_selects_that_branch() {
+        let repo = Repository::new("demo".into(), "/tmp/demo".into());
+        let mut modal = Modal::AddWorktree(Box::new(AddWorktreeModal::new(
+            &repo,
+            vec!["main".into(), "feat/login".into()],
+            vec![],
+            PathBuf::from("/forest"),
+            "feat/".into(),
+        )));
+        let expected = if let Modal::AddWorktree(m) = &mut modal {
+            m.name.set_value("wt");
+            m.new_branch = false;
+            assert!(!m.can_create(), "nothing is picked yet");
+            m.matches()[1].0.clone()
+        } else {
+            panic!("add worktree modal expected")
+        };
+
+        modal.set_row(1);
+
+        let Modal::AddWorktree(m) = &modal else {
+            panic!("add worktree modal expected")
+        };
+        assert_eq!(m.selected_branch(), expected);
+        assert!(m.can_create(), "the clicked branch was never committed");
     }
 
     #[test]

--- a/src/services/git.rs
+++ b/src/services/git.rs
@@ -100,11 +100,11 @@ async fn safe_list_remotes(path: &str) -> Vec<String> {
 }
 
 /// List branches. Remote branches keep their `<remote>/` prefix.
-pub async fn list_branches(path: &str, include_remote: bool) -> GitResult<Vec<String>> {
+pub async fn list_branches(path: &str) -> GitResult<Vec<String>> {
     let dir = expand(path);
-    // Always needed: `git branch -a` lists remote branches either way, so without
-    // the remote names they cannot be classified — and would leak into the result
-    // when the caller asked for local branches only.
+    // `git branch -a` returns remote refs and the bare remote names alongside
+    // the local branches, and neither can be told apart without knowing what
+    // the remotes are called.
     let remotes = safe_list_remotes(path).await;
 
     let (code, stdout, stderr) =
@@ -121,10 +121,6 @@ pub async fn list_branches(path: &str, include_remote: bool) -> GitResult<Vec<St
         }
         // Skip bare remote names (e.g. "origin" without a branch).
         if remotes.iter().any(|r| r == line) {
-            continue;
-        }
-        let is_remote = remotes.iter().any(|r| line.starts_with(&format!("{r}/")));
-        if is_remote && !include_remote {
             continue;
         }
         branches.push(line.to_string());
@@ -459,7 +455,7 @@ mod tests {
         assert!(list_worktrees(&repo_str).await.is_ok());
         assert_eq!(get_current_branch(&repo_str).await.unwrap(), "main");
         assert!(
-            list_branches(&repo_str, true)
+            list_branches(&repo_str)
                 .await
                 .unwrap()
                 .contains(&"main".to_string())
@@ -474,7 +470,7 @@ mod tests {
             .unwrap();
         assert!(wt.exists());
         assert!(
-            list_branches(&repo_str, true)
+            list_branches(&repo_str)
                 .await
                 .unwrap()
                 .contains(&"feat/x".to_string())
@@ -511,10 +507,10 @@ mod tests {
         git_in(path, &["commit", "--allow-empty", "-m", "init"]);
     }
 
-    /// `include_remote = false` must not leak `origin/…` refs, which
-    /// `git branch -a` returns regardless of what the caller asked for.
+    /// `git branch -a` returns more than branches: the bare remote names and
+    /// `origin/HEAD` come back too, and neither is something to check out.
     #[tokio::test]
-    async fn list_branches_excludes_remotes_when_not_requested() {
+    async fn list_branches_keeps_remote_branches_but_not_remote_names() {
         let dir = tempfile::tempdir().unwrap();
 
         let upstream = dir.path().join("upstream");
@@ -530,14 +526,12 @@ mod tests {
         git_in(&clone, &["fetch", "--no-tags", "origin"]);
         let clone_str = clone.to_string_lossy().to_string();
 
-        let local = list_branches(&clone_str, false).await.unwrap();
-        assert_eq!(local, vec!["main".to_string()]);
-
-        let all = list_branches(&clone_str, true).await.unwrap();
+        let all = list_branches(&clone_str).await.unwrap();
         assert!(all.contains(&"main".to_string()));
         assert!(all.contains(&"origin/main".to_string()));
         assert!(all.contains(&"origin/feat/remote-only".to_string()));
-        // The bare remote name is not a branch.
+        // The bare remote name is not a branch, and neither is its HEAD.
         assert!(!all.contains(&"origin".to_string()));
+        assert!(!all.iter().any(|b| b.ends_with("/HEAD")));
     }
 }

--- a/src/services/github.rs
+++ b/src/services/github.rs
@@ -47,11 +47,15 @@ fn state() -> &'static Mutex<State> {
     STATE.get_or_init(|| Mutex::new(State::default()))
 }
 
-/// A signal-killed process must not read as success — and equally not as -1,
-/// which is reserved for "gh is not installed" and would flip the sidebar to
-/// [`AuthStatus::NotInstalled`] for the rest of the process.
+/// Exit code reserved for a process that died to a signal.
+///
+/// It cannot be `0` (success), `-1` (reserved for "gh is not installed"), or
+/// `1` — `gh auth status` returns 1 for "not logged in", and conflating the two
+/// let one killed probe pin the whole session to "unauth'd".
+pub const KILLED: i32 = -2;
+
 fn exit_code(status: std::process::ExitStatus) -> i32 {
-    crate::util::exit_code(status, 1)
+    crate::util::exit_code(status, KILLED)
 }
 
 /// Run a `gh` command. Exit code `-1` means the binary is missing.
@@ -81,6 +85,12 @@ pub async fn get_auth_status() -> (AuthStatus, Option<String>) {
     }
 
     let (code, _out, _err) = run_gh(&["auth", "status"], None).await;
+    if code == KILLED {
+        // A probe that was killed answered nothing. Caching that as an answer
+        // would leave the sidebar reading "unauth'd" and the issues list empty
+        // for the rest of the session, with no path back short of a restart.
+        return (AuthStatus::NotAuthenticated, None);
+    }
     let result = if code == -1 {
         (AuthStatus::NotInstalled, None)
     } else if code == 0 {
@@ -224,8 +234,9 @@ mod tests {
         assert_eq!(AuthStatus::NotInstalled.display(None), "missing");
     }
 
-    /// A killed `gh` must fail, but must not masquerade as a missing binary:
-    /// -1 would flip the sidebar to "missing" for the rest of the process.
+    /// A killed `gh` must fail, but must not masquerade as a missing binary
+    /// (-1 flips the sidebar to "missing"), nor as a real "not logged in"
+    /// (1, which `get_auth_status` caches for the lifetime of the process).
     #[test]
     fn signal_killed_process_is_a_plain_failure() {
         let status = std::process::Command::new("sh")
@@ -236,6 +247,12 @@ mod tests {
         let code = exit_code(status);
         assert_ne!(code, 0);
         assert_ne!(code, -1);
+        assert_ne!(
+            code, 1,
+            "a killed probe is indistinguishable from `gh auth status` saying \
+             'not logged in', which is cached and never retried"
+        );
+        assert_eq!(code, KILLED);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,14 @@ pub struct AppState {
     pub selection: Selection,
     pub show_archived: bool,
     config_path: PathBuf,
+    /// Why the last [`AppState::save`] failed, if it did.
+    ///
+    /// A failed write used to be discarded outright, so the app went on to
+    /// announce "Created worktree 'x'" for a worktree that never reached the
+    /// config — the loudest possible lie, because a corrupt or missing file
+    /// loads as *empty* state and the entry is simply gone on the next launch.
+    /// Callers that announce success drain this first.
+    save_error: Option<String>,
 }
 
 impl AppState {
@@ -37,19 +45,31 @@ impl AppState {
             selection: Selection::default(),
             show_archived: false,
             config_path,
+            save_error: None,
         }
     }
 
-    fn save(&self) {
+    fn save(&mut self) {
         if let Some(parent) = self.config_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
         let data = AppStateData {
             repositories: self.repositories.clone(),
         };
-        if let Ok(json) = serde_json::to_string_pretty(&data) {
-            let _ = crate::util::write_atomically(&self.config_path, &json);
-        }
+        self.save_error = match serde_json::to_string_pretty(&data) {
+            Ok(json) => crate::util::write_atomically(&self.config_path, &json)
+                .err()
+                .map(|error| error.to_string()),
+            Err(error) => Some(error.to_string()),
+        };
+    }
+
+    /// Take the last save failure, if the most recent write did not land.
+    ///
+    /// Draining it means one failure is reported once, by whoever was about to
+    /// claim the change succeeded.
+    pub fn take_save_error(&mut self) -> Option<String> {
+        self.save_error.take()
     }
 
     pub fn repositories(&self) -> &[Repository] {

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -61,6 +61,14 @@ pub fn draw(frame: &mut Frame, app: &mut App, area: Rect) {
     // resolve against the frame the user saw, not a list a background event
     // may have reshaped since (see `App::drawn_items`).
     app.drawn_items = crate::app::detail::drawn(&nodes);
+    // The pane can shrink under the cursor — the issue auto-refresh returning
+    // fewer issues than last time is enough — and an index left past the end
+    // resolves to nothing: the focus ring disappears and Enter does nothing
+    // until the user presses Down. Clamped here because this is the one place
+    // both consumers of the snapshot agree on its length.
+    if app.detail_index >= app.drawn_items.len() {
+        app.detail_index = app.drawn_items.len().saturating_sub(1);
+    }
     if nodes.is_empty() {
         app.scrollbar = None;
         empty_state(frame, area);
@@ -925,6 +933,36 @@ mod tests {
         );
         // Following is a one-shot: it must not fight the wheel on later frames.
         assert!(!app.detail_follow_focus);
+    }
+
+    /// The pane shrinks under the cursor whenever the issue auto-refresh comes
+    /// back with fewer issues than last time. An index left past the end is a
+    /// focus ring that vanishes and an Enter that does nothing.
+    #[tokio::test]
+    async fn a_shrinking_pane_pulls_the_cursor_back_into_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = test_app(&dir);
+        with_repository(&mut app);
+        app.sessions = Some(vec![a_session()]);
+        app.issues = Some(vec![an_issue(), an_issue(), an_issue()]);
+        app.focus = Focus::Detail;
+        app.detail_index = app.detail_items().len() - 1;
+        render_buffer(&mut app, 100, TALL);
+
+        // One issue was closed on GitHub since the last refresh.
+        app.issues = Some(vec![an_issue()]);
+        render_buffer(&mut app, 100, TALL);
+
+        assert!(
+            app.detail_index < app.drawn_items.len(),
+            "index {} is past the end of {} items",
+            app.detail_index,
+            app.drawn_items.len()
+        );
+        assert!(
+            app.drawn_items.get(app.detail_index).is_some(),
+            "the focused slot resolves to nothing, so Enter is dead"
+        );
     }
 
     /// The wheel scrolls the pane whoever has focus, which is the whole point of

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -935,6 +935,29 @@ mod tests {
         assert!(!app.detail_follow_focus);
     }
 
+    /// `draw` is the only thing that ever writes `App::drawn_items`, and every
+    /// activation — Enter and click alike — resolves against it. Delete that one
+    /// line and the whole pane goes inert while every other test stays green,
+    /// because they all snapshot it by hand.
+    #[tokio::test]
+    async fn drawing_the_pane_snapshots_what_it_drew() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = test_app(&dir);
+        with_repository(&mut app);
+        app.sessions = Some(vec![a_session()]);
+        app.issues = Some(vec![an_issue()]);
+        app.drawn_items.clear();
+
+        render_buffer(&mut app, 100, TALL);
+
+        assert!(!app.drawn_items.is_empty(), "the frame snapshotted nothing");
+        assert_eq!(
+            app.drawn_items,
+            crate::app::detail::drawn(&crate::app::detail::content(&app)),
+            "the snapshot is not what the frame drew"
+        );
+    }
+
     /// The pane shrinks under the cursor whenever the issue auto-refresh comes
     /// back with fewer issues than last time. An index left past the end is a
     /// focus ring that vanishes and an Enter that does nothing.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -126,7 +126,7 @@ fn draw_footer(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
-fn draw_notifications(frame: &mut Frame, app: &App, area: Rect) {
+fn draw_notifications(frame: &mut Frame, app: &mut App, area: Rect) {
     if app.notifications.is_empty() {
         return;
     }
@@ -168,6 +168,8 @@ fn draw_notifications(frame: &mut Frame, app: &App, area: Rect) {
 
     frame.render_widget(Clear, rect);
     frame.render_widget(Paragraph::new(lines), rect);
+    // Recorded after the panes, so it wins the cells it covers.
+    app.push_hit(rect, HitTarget::Notification);
 }
 
 /// Break text into lines of at most `width` characters, on word boundaries
@@ -207,6 +209,28 @@ fn wrap_words(text: &str, width: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The toast is drawn over the detail pane, so the frame that draws it has
+    /// to claim its cells — otherwise a click there reaches the control beneath.
+    #[tokio::test]
+    async fn drawing_a_toast_records_its_region() {
+        use crate::app::test_support::app_with_fixture;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let (_dir, mut app) = app_with_fixture();
+        app.notify("something happened", Severity::Information);
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("test terminal");
+        terminal.draw(|frame| draw(frame, &mut app)).expect("draw");
+
+        assert!(
+            app.hits
+                .iter()
+                .any(|hit| hit.target == HitTarget::Notification),
+            "the toast drew but claimed no cells"
+        );
+    }
 
     #[test]
     fn wrap_words_breaks_on_word_boundaries() {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -6,7 +6,7 @@
 //! drift apart — both sides name the same `FOCUS_*` constants on the modal
 //! struct rather than repeating a number, so there is one place to change.
 
-use crate::app::{App, HitTarget, ModalClick};
+use crate::app::{App, Direction, HitTarget, ModalClick};
 use crate::modal::{
     AddRepositoryModal, AddWorktreeModal, ConfirmModal, CreateFromIssueModal, CustomButtonsModal,
     EDITORS, EditButtonModal, Modal, SPINNER, SettingsModal, THEMES,
@@ -338,13 +338,21 @@ fn cycle(value: &str, focused: bool, index: usize) -> Control {
         theme::Variant::Normal,
         index,
     );
-    (spans, width, index, ModalClick::Cycle)
+    (spans, width, index, ModalClick::Cycle(Direction::Next))
+}
+
+/// One segment of a two-option row, which selects itself rather than toggling
+/// the row. `direction` is the key that lands on this option: the pair reads as
+/// Left for the first and Right for the second, both idempotent.
+fn option(label: &str, active: bool, index: usize, direction: Direction) -> Control {
+    let (spans, width, index, _) = control(label, active, theme::Variant::Normal, index);
+    (spans, width, index, ModalClick::Cycle(direction))
 }
 
 /// A bare arrow beside a control, standing for the key that drives it. Clicking
 /// one does what that key does, so it carries the control's index too. It is one
 /// cell wide on all three rows, so the buttons after it stay aligned.
-fn arrow(glyph: char, focused: bool, index: usize) -> Control {
+fn arrow(glyph: char, direction: Direction, focused: bool, index: usize) -> Control {
     let style = if focused {
         theme::accent()
     } else {
@@ -359,7 +367,7 @@ fn arrow(glyph: char, focused: bool, index: usize) -> Control {
         ],
         1,
         index,
-        ModalClick::Cycle,
+        ModalClick::Cycle(direction),
     )
 }
 
@@ -453,18 +461,20 @@ fn add_worktree(frame: &mut Frame, modal: &AddWorktreeModal, area: Rect, hits: &
 
     column.line(frame, widgets::section("Branch"));
     // Left/Right switch modes here, so the arrows are literal: they light up
-    // only while the toggle holds the focus. The whole row is one control, so
-    // every part of it toggles — which is what Enter on it does too.
+    // only while the toggle holds the focus. Each option *selects* itself
+    // rather than toggling the row — Left is "New Branch" and Right is
+    // "Existing" whichever is current, so clicking the option that is already
+    // active does nothing instead of switching away from it.
     let mode = AddWorktreeModal::FOCUS_MODE;
     let toggle_focused = modal.focus == mode;
     column.controls(
         frame,
         hits,
         vec![
-            arrow('◂', toggle_focused, mode),
-            control("New Branch", modal.new_branch, theme::Variant::Normal, mode),
-            control("Existing", !modal.new_branch, theme::Variant::Normal, mode),
-            arrow('▸', toggle_focused, mode),
+            arrow('◂', Direction::Previous, toggle_focused, mode),
+            option("New Branch", modal.new_branch, mode, Direction::Previous),
+            option("Existing", !modal.new_branch, mode, Direction::Next),
+            arrow('▸', Direction::Next, toggle_focused, mode),
         ],
         false,
     );
@@ -999,6 +1009,19 @@ mod tests {
         (column, row as u16)
     }
 
+    /// What a click on a cell does, resolved the way `App::hit_at` does.
+    fn index_click(hits: &Hits, (column, row): (u16, u16)) -> Option<ModalClick> {
+        hits.iter()
+            .rev()
+            .find(|(rect, _, _)| {
+                column >= rect.x
+                    && column < rect.x + rect.width
+                    && row >= rect.y
+                    && row < rect.y + rect.height
+            })
+            .map(|(_, _, click)| *click)
+    }
+
     /// The focus index recorded for a cell, resolved the way `App::hit_at` does.
     fn index_at(hits: &Hits, (column, row): (u16, u16)) -> Option<usize> {
         hits.iter()
@@ -1158,6 +1181,30 @@ mod tests {
             }
         }
         assert!(checked >= 20, "expected every modal at every height");
+    }
+
+    /// Clicking the mode option that is already active must not switch away
+    /// from it. Both segments used to carry the row's Enter, which toggles.
+    #[test]
+    fn clicking_the_active_mode_option_keeps_it() {
+        let modal = worktree_modal(true);
+        let (screen, hits) = render_with_hits(&modal, 100, 30);
+
+        let new_branch = index_click(&hits, cell_of(&screen, "New Branch"));
+        let existing = index_click(&hits, cell_of(&screen, "Existing"));
+
+        // Left selects "New Branch", Right selects "Existing" — the same key
+        // whichever mode is current, so re-clicking the active one is a no-op.
+        assert_eq!(
+            new_branch,
+            Some(ModalClick::Cycle(Direction::Previous)),
+            "the New Branch pill does not select New Branch"
+        );
+        assert_eq!(
+            existing,
+            Some(ModalClick::Cycle(Direction::Next)),
+            "the Existing pill does not select Existing"
+        );
     }
 
     #[test]

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -181,16 +181,27 @@ impl Column {
         // answered from the keyboard, with nothing on screen saying so — pin it
         // to the last three rows. The body above it loses those rows instead,
         // which is at least visible.
-        let rect = self.take(BUTTON_HEIGHT).unwrap_or_else(|| {
-            let y = (self.area.y + self.area.height).saturating_sub(BUTTON_HEIGHT);
-            self.y = self.area.y + self.area.height;
-            Rect {
-                x: self.area.x,
-                y,
-                width: self.area.width,
-                height: BUTTON_HEIGHT.min(self.area.height),
+        let rect = match self.take(BUTTON_HEIGHT) {
+            Some(rect) => rect,
+            None => {
+                let y = (self.area.y + self.area.height).saturating_sub(BUTTON_HEIGHT);
+                self.y = self.area.y + self.area.height;
+                let pinned = Rect {
+                    x: self.area.x,
+                    y,
+                    width: self.area.width,
+                    height: BUTTON_HEIGHT.min(self.area.height),
+                };
+                // Every row that overflows lands on this same strip, so an
+                // earlier one is painted over by whatever comes after it.
+                // Its hit regions have to go with it: a control nobody can see
+                // must not answer a click, and the blank margin either side of
+                // a centred button row is exactly where those stale regions
+                // would still be sitting.
+                hits.retain(|(recorded, _, _)| !recorded.intersects(pinned));
+                pinned
             }
-        });
+        };
         let total = controls
             .iter()
             .map(|(_, width, _, _)| width.saturating_add(GAP))
@@ -1112,6 +1123,41 @@ mod tests {
             );
         }
         assert!(checked >= 4, "expected several modals to have buttons");
+    }
+
+    /// The other half of the short-terminal contract: what is *not* drawn must
+    /// not be clickable.
+    ///
+    /// Every row that overflows the dialog is pinned to the same three rows at
+    /// the bottom, so each one is painted over by whatever is drawn after it.
+    /// Their hit regions used to survive that, stacked on top of each other —
+    /// an invisible control answering clicks from the margin around the row
+    /// that replaced it. Two controls claiming one cell is the signature, and
+    /// no dialog that fits has any business producing it either.
+    #[test]
+    fn controls_never_claim_the_same_cell_twice() {
+        let mut checked = 0;
+        for (modal, title) in every_modal() {
+            for height in [8, 10, 12, 14, 24] {
+                let (screen, hits) = render_with_hits(&modal, 80, height);
+                checked += 1;
+
+                for (a, first) in hits.iter().enumerate() {
+                    for second in hits.iter().skip(a + 1) {
+                        assert!(
+                            !first.0.intersects(second.0),
+                            "{title} at 80x{height}: focus {} and focus {} both \
+                             claim {:?} ∩ {:?} — one of them is not on screen:\n{screen}",
+                            first.1,
+                            second.1,
+                            first.0,
+                            second.0
+                        );
+                    }
+                }
+            }
+        }
+        assert!(checked >= 20, "expected every modal at every height");
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -170,22 +170,67 @@ pub fn exit_code(status: std::process::ExitStatus, sentinel: i32) -> i32 {
 /// impossible: readers see either the old file or the new one, never a torn
 /// half. The temp file lives beside the target because a rename is only atomic
 /// within one filesystem.
+///
+/// Three details keep the swap from being a downgrade on `fs::write`, which it
+/// replaced:
+///
+/// - It writes through a symlink. A rename would replace the link itself, so a
+///   config symlinked into a dotfiles repo would silently stop syncing after
+///   the first save.
+/// - It carries the target's existing permissions onto the replacement. A fresh
+///   temp file is born at the umask default, which would quietly widen a config
+///   the user had locked down.
+/// - It fsyncs the contents before the rename, and the directory after it.
+///   Without the first, a power loss can land the rename but not the bytes,
+///   leaving the empty file that loads as empty state — the exact loss this
+///   function exists to prevent.
 pub fn write_atomically(path: &Path, contents: &str) -> std::io::Result<()> {
-    let mut temp = path.to_path_buf();
-    let mut name = path
+    // Resolve the link before choosing a sibling, so both the temp file and the
+    // rename land in the directory that actually holds the data.
+    let target = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    let mut temp = target.clone();
+    let mut name = target
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "file".to_string());
     name.push_str(&format!(".tmp-{}", std::process::id()));
     temp.set_file_name(name);
 
-    std::fs::write(&temp, contents)?;
-    let renamed = std::fs::rename(&temp, path);
-    if renamed.is_err() {
+    let result = write_temp_then_rename(&temp, &target, contents);
+    if result.is_err() {
         // Leave no half-written sibling behind; the original is untouched.
         let _ = std::fs::remove_file(&temp);
     }
-    renamed
+    result
+}
+
+/// The fallible half of [`write_atomically`], split out so one cleanup on the
+/// error path covers a failure at any step rather than only at the rename.
+fn write_temp_then_rename(temp: &Path, target: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut file = std::fs::File::create(temp)?;
+    file.write_all(contents.as_bytes())?;
+    // Durability before visibility: the rename is only atomic for readers, not
+    // for the disk.
+    file.sync_all()?;
+    drop(file);
+
+    if let Ok(existing) = std::fs::metadata(target) {
+        std::fs::set_permissions(temp, existing.permissions())?;
+    }
+
+    std::fs::rename(temp, target)?;
+
+    // Best effort: a directory fsync is what makes the rename itself durable,
+    // and there is nothing useful to do when a platform refuses to open one.
+    if let Some(parent) = target.parent()
+        && let Ok(dir) = std::fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
+    Ok(())
 }
 
 fn levenshtein_distance(s1: &[char], s2: &[char]) -> usize {
@@ -453,6 +498,42 @@ mod tests {
             .filter(|e| e.file_name() != "config.json")
             .collect();
         assert!(leftovers.is_empty(), "temp file left behind: {leftovers:?}");
+    }
+
+    #[test]
+    fn atomic_write_follows_a_symlinked_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("dotfiles");
+        std::fs::create_dir(&real).unwrap();
+        let data = real.join("config.json");
+        std::fs::write(&data, "old").unwrap();
+
+        let link = dir.path().join("config.json");
+        std::os::unix::fs::symlink(&data, &link).unwrap();
+
+        write_atomically(&link, "new").unwrap();
+
+        // Renaming over the link would leave a regular file here and strand the
+        // dotfiles copy on the old contents forever.
+        assert!(link.is_symlink(), "the symlink was replaced by a real file");
+        assert_eq!(std::fs::read_to_string(&data).unwrap(), "new");
+    }
+
+    #[test]
+    fn atomic_write_keeps_the_targets_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_atomically(&target, "new").unwrap();
+
+        // A fresh temp file is born at the umask default; carrying it onto the
+        // target would widen a config the user deliberately locked down.
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "permissions were widened to {mode:o}");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #34 — this targets `feat/fable-review`, not `main`, so the diff is only the review fixes.

A multi-angle review pass over #34 (app split, state/concurrency, pointer handling, modals/services, unit tests, use-cases/docs) turned up 15 defects. Every one was reproduced before it was touched, and the fixes that guard against a silent regression carry a test that was mutation-checked — revert the fix, watch the new test fail, put it back.

`make check` green (137 → 152 tests), clean under `--features binary-release`, and a fresh `tu` sweep shows no new assertion failures and no frame regressions.

## Introduced by #34

**Persistence** — `write_atomically` closed the torn-file window but opened four others. It renamed *over* a symlink, so a config symlinked into a dotfiles repo silently stopped syncing after the first save. It reset the target's permissions to the umask default, widening a `chmod 600` config back to 0644. It fsynced nothing, so a power loss could land the rename without the bytes — leaving the empty file that deliberately loads as *empty state*, the exact loss the function exists to prevent. And its cleanup only ran when the *rename* failed, so a write that died mid-way leaked `.forestui-config.json.tmp-<pid>`, one per launch.

**`save()` discarded its error while the fold announced success.** The toast was deliberately moved into the fold so a *dropped* result can't announce a phantom worktree — but the write itself was unchecked, so it lied in exactly the case the design cares about. Read-only forest → "Created worktree 'foo'" → gone on next launch, with the git worktree still on disk.

**The off-loop rename left the field holding the old name.** The rename inputs are only re-seeded when the *target* changes. Rename, navigate away and back while the task runs, and the field re-seeds to the pre-rename name; the fold then lands and leaves it there. Pressing Enter renamed the worktree straight back. This window did not exist on `main`, where the update was synchronous with the keypress.

**`WorktreesImported` stole the selection.** A slow import landing after you had navigated on yanked the cursor back and discarded the sessions and issues you were reading. No detail pane shows imported worktrees, so rebuilding the sidebar rows is the whole job.

**The `gh` signal sentinel collided with "not logged in".** `main` used `unwrap_or(0)`; #34 used `1`, which is what `gh auth status` returns when you are logged out — and that answer is cached for the process lifetime, with `invalidate_cache` clearing only the *issue* cache. One OOM-killed probe pinned the sidebar to "unauth'd" and the issues list to empty until restart.

## Pre-existing — identical on `main`, but real

**A click on a notification toast fell through to the control underneath.** The toast is drawn over the detail pane and recorded no hit region. On a session card that control is `New Session: YOLO`, so a click on a toast could start a `--dangerously-skip-permissions` session.

**Invisible modal controls stayed clickable.** Every row that overflows a short dialog is pinned to the same bottom strip, so each is painted over by the next — but the hit regions stacked. At 80x8 the Add Repository checkbox kept a 33-cell region across the button row, so a click on the blank margin beside "Cancel" toggled an import nobody could see.

**A modal owned the click but not the wheel.** The panes behind a dialog are still drawn and still hit-testable, so scrolling over an open modal reselected the sidebar underneath it — each notch a fresh `reload_detail`, three git subprocesses and a `gh issue list` — and a dialog wide enough to cover the scrollbar track ate presses meant for its own buttons.

Also: on the Add Worktree mode row, where the arrows are separate click targets, both `◂` and `▸` advanced the value (Settings draws `◂ value ▸` as one region, which advances on click by design — unchanged); clicking the already-active mode option switched away from it; clicking a branch row moved the highlight without picking the branch, leaving Create permanently disabled for mouse-only users; `detail_index` was never clamped when the pane shrank, which the 5-minute issue refresh does whenever an issue is closed upstream; footer-key clicks were replayed as synthetic keystrokes so a focused rename field ate them as text; the branch rename wrote and persisted the new name *before* `git branch -m` ran and never rolled back; `pending_issue` was an index into a list that gets replaced wholesale, so the modal could open on another repository's issue and create the worktree in the wrong repo; and a stale scrollbar grab survived a lost release.

`list_branches`' `include_remote` flag turned out to be dead flexibility rather than a defect — only `true` was ever passed, so the leak it guarded could not happen and the guard was reachable only from its own test. Removed; the test now covers what the live call relies on.

## Tests and docs

The count-match invariant still has teeth (mutation-checked three ways). But **nothing covered `draw` writing `App::drawn_items`** — the one line that makes the detail pane clickable at all. Deleting it left 137/137 green while every control went inert, because the app tests all snapshot it by hand. Covered now.

The harness could pass without seeing the screen it claims to compare: `await` swallowed its exit status, so a timed-out wait captured whatever was on screen and diffed clean against a baseline captured the same way; `await "[^n]Archive"` matched the footer's own ` h Archive ` on every frame; `await "edit:alpha"` matched the status bar the previous case had left behind. Fixed, and timeouts are counted and reported.

UC-95/96 existed only inside the sweep script while CLAUDE.md cited UC-96 as the guard against uncompared sections — both are written up. UC-13 claimed disabled controls are "not focusable" (they never have been: they keep their slot so indices behind them do not shift, and are inert instead); UC-59 still described the nine-key toast its own refreshed baseline contradicts; UC-89 described filled pills where every baseline shows bordered boxes; and MIGRATION claimed mouse support was dropped with no capture enabled, which is four files of `src/app/mouse.rs` out of date.

## Verified, not assumed

UC-59's refreshed baseline is legitimate rather than a masked regression: I built the branch and re-ran the sweep, the frame reproduces exactly, and all 14 bindings in the new toast have a `handle_key` arm.

The sweep's UC-78/79/80/83/84 assertions fail on my machine — **but they fail identically on `main`**, confirmed by building it and running the same sweep as a control. Pre-existing harness fragility, not #34, and left alone here. Related: the LOCATION box hugs its content, so the absolute path length leaks into supposedly normalised frames, which is part of why committed baselines do not reproduce across machines.

## Deliberately not fixed

The sidebar wheel moves the selection unthrottled (~40-90 subprocesses per flick) — that is Textual parity, so changing it is a product decision rather than a review fix. And background work completing after `q` never reaches the fold, because `drain` discards queued events once `should_quit` is set; fixing that means a shutdown drain, which is more than a review pass should smuggle in.

