### PR TITLE
Stop deleting uncommitted work without asking

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -7,7 +7,7 @@
 
 use super::{Action, App, Field};
 use crate::event::Severity;
-use crate::event::{AppEvent, BranchTarget, EventTx};
+use crate::event::{AppEvent, BranchTarget, EventTx, WorktreeRemoval};
 use crate::modal::ModalOutcome;
 use crate::modal::{
     AddWorktreeModal, ConfirmAction, ConfirmModal, CreateFromIssueModal, Modal, ModalEffect,
@@ -130,15 +130,39 @@ impl App {
                 let repo_path = repo.source_path.clone();
                 let worktree_path = worktree.path.clone();
                 let tx = self.tx.clone();
+                // The entry leaves state only when git has actually removed the
+                // worktree — the fold decides, so a dirty refusal can stop here
+                // with everything intact.
                 tokio::spawn(async move {
-                    // A failed git removal must not strand the entry in state.
-                    let _ = git::remove_worktree(&repo_path, &worktree_path).await;
-                    tx.send(AppEvent::ReloadDetail);
+                    let outcome = match git::remove_worktree(&repo_path, &worktree_path).await {
+                        Ok(git::RemoveOutcome::Removed) => WorktreeRemoval::Removed,
+                        Ok(git::RemoveOutcome::Dirty(summary)) => WorktreeRemoval::Dirty(summary),
+                        Err(error) => WorktreeRemoval::Failed(error.to_string()),
+                    };
+                    tx.send(AppEvent::WorktreeRemoveResult {
+                        worktree_id,
+                        outcome,
+                    });
                 });
-                self.state.remove_worktree(worktree_id);
-                self.rebuild_rows();
-                self.sync_sidebar_index();
-                self.reload_detail();
+            }
+            ConfirmAction::ForceDeleteWorktree(worktree_id) => {
+                let Some((repo, worktree)) = self.state.find_worktree(worktree_id) else {
+                    return;
+                };
+                let repo_path = repo.source_path.clone();
+                let worktree_path = worktree.path.clone();
+                let tx = self.tx.clone();
+                tokio::spawn(async move {
+                    let outcome = match git::force_remove_worktree(&repo_path, &worktree_path).await
+                    {
+                        Ok(()) => WorktreeRemoval::Removed,
+                        Err(error) => WorktreeRemoval::Failed(error.to_string()),
+                    };
+                    tx.send(AppEvent::WorktreeRemoveResult {
+                        worktree_id,
+                        outcome,
+                    });
+                });
             }
         }
     }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -7,7 +7,7 @@
 
 use super::{Action, App, Field};
 use crate::event::Severity;
-use crate::event::{AppEvent, BranchTarget, EventTx, WorktreeRemoval};
+use crate::event::{AppEvent, BranchTarget, EventTx};
 use crate::modal::ModalOutcome;
 use crate::modal::{
     AddWorktreeModal, ConfirmAction, ConfirmModal, CreateFromIssueModal, Modal, ModalEffect,
@@ -124,47 +124,47 @@ impl App {
                 self.reload_detail();
             }
             ConfirmAction::DeleteWorktree(worktree_id) => {
-                let Some((repo, worktree)) = self.state.find_worktree(worktree_id) else {
-                    return;
-                };
-                let repo_path = repo.source_path.clone();
-                let worktree_path = worktree.path.clone();
-                let tx = self.tx.clone();
-                // The entry leaves state only when git has actually removed the
-                // worktree — the fold decides, so a dirty refusal can stop here
-                // with everything intact.
-                tokio::spawn(async move {
-                    let outcome = match git::remove_worktree(&repo_path, &worktree_path).await {
-                        Ok(git::RemoveOutcome::Removed) => WorktreeRemoval::Removed,
-                        Ok(git::RemoveOutcome::Dirty(summary)) => WorktreeRemoval::Dirty(summary),
-                        Err(error) => WorktreeRemoval::Failed(error.to_string()),
-                    };
-                    tx.send(AppEvent::WorktreeRemoveResult {
-                        worktree_id,
-                        outcome,
-                    });
-                });
+                self.spawn_worktree_removal(worktree_id, false);
             }
             ConfirmAction::ForceDeleteWorktree(worktree_id) => {
-                let Some((repo, worktree)) = self.state.find_worktree(worktree_id) else {
-                    return;
-                };
-                let repo_path = repo.source_path.clone();
-                let worktree_path = worktree.path.clone();
-                let tx = self.tx.clone();
-                tokio::spawn(async move {
-                    let outcome = match git::force_remove_worktree(&repo_path, &worktree_path).await
-                    {
-                        Ok(()) => WorktreeRemoval::Removed,
-                        Err(error) => WorktreeRemoval::Failed(error.to_string()),
-                    };
-                    tx.send(AppEvent::WorktreeRemoveResult {
-                        worktree_id,
-                        outcome,
-                    });
-                });
+                self.spawn_worktree_removal(worktree_id, true);
             }
         }
+    }
+
+    /// Run a worktree removal in the background. The entry leaves state only
+    /// when git has actually removed the worktree — the fold decides, so a
+    /// dirty refusal can stop with everything intact.
+    fn spawn_worktree_removal(&mut self, worktree_id: Uuid, force: bool) {
+        let Some((repo, worktree)) = self.state.find_worktree(worktree_id) else {
+            return;
+        };
+        // A second confirm on the same worktree while git is still running
+        // would race a duplicate removal and stack a second destructive modal.
+        if !self.removals_in_flight.insert(worktree_id) {
+            return;
+        }
+        let repo_path = repo.source_path.clone();
+        let worktree_path = worktree.path.clone();
+        let name = worktree.name.clone();
+        // Immediate feedback: on a large tree the round trip takes seconds and
+        // the frame would otherwise be identical to the one before confirming.
+        self.notify(format!("Deleting '{name}'…"), Severity::Information);
+        let tx = self.tx.clone();
+        tokio::spawn(async move {
+            let outcome = if force {
+                git::force_remove_worktree(&repo_path, &worktree_path)
+                    .await
+                    .map(|()| git::RemoveOutcome::Removed)
+            } else {
+                git::remove_worktree(&repo_path, &worktree_path).await
+            }
+            .map_err(|error| error.to_string());
+            tx.send(AppEvent::WorktreeRemoveResult {
+                worktree_id,
+                outcome,
+            });
+        });
     }
 
     pub(super) fn on_branches(
@@ -252,6 +252,9 @@ impl App {
         if let Some((_repo, worktree)) = self.state.selected_worktree() {
             let name = worktree.name.clone();
             let id = worktree.id;
+            if self.removals_in_flight.contains(&id) {
+                return;
+            }
             self.modals.push(Modal::Confirm(ConfirmModal::new(
                 "Delete Worktree",
                 format!("Permanently delete '{name}'?"),

--- a/src/app/detail.rs
+++ b/src/app/detail.rs
@@ -251,6 +251,9 @@ fn worktree(nodes: &mut Vec<DetailNode>, app: &App) {
     let name = selected.map(|(_, w)| w.name.as_str()).unwrap_or_default();
     let branch = selected.map(|(_, w)| w.branch.as_str()).unwrap_or_default();
     let archived = selected.map(|(_, w)| w.is_archived).unwrap_or(false);
+    let deleting = selected
+        .map(|(_, w)| app.removals_in_flight.contains(&w.id))
+        .unwrap_or(false);
 
     nodes.push(DetailNode::Section("WORKTREE"));
     text(nodes, format!("Repository: {repository}"), theme::title());
@@ -315,7 +318,11 @@ fn worktree(nodes: &mut Vec<DetailNode>, app: &App) {
             } else {
                 ControlSpec::new(Action::Archive, "Archive", theme::Variant::Normal)
             },
-            ControlSpec::new(Action::Delete, "Delete", theme::Variant::Destructive),
+            if deleting {
+                ControlSpec::disabled(Action::Delete, "Deleting…")
+            } else {
+                ControlSpec::new(Action::Delete, "Delete", theme::Variant::Destructive)
+            },
         ],
     );
     bottom_padding(nodes);

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -36,7 +36,7 @@ impl App {
         use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-            self.should_quit = true;
+            self.request_quit();
             return;
         }
 
@@ -140,7 +140,7 @@ impl App {
         use ratatui::crossterm::event::KeyCode;
 
         match KeyCode::Char(binding) {
-            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('q') => self.request_quit(),
             KeyCode::Char('a') => self
                 .modals
                 .push(Modal::AddRepository(AddRepositoryModal::new())),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,7 +15,7 @@ pub use detail::{Action, DetailItem, Field};
 pub use keys::BINDINGS;
 pub use mouse::{Direction, Hit, HitTarget, ModalClick, ScrollbarGeom};
 
-use crate::event::{AppEvent, DetailMeta, EventTx, Severity, WorktreeRemoval};
+use crate::event::{AppEvent, DetailMeta, EventTx, Severity};
 use crate::modal::Modal;
 use crate::models::{ClaudeSession, GitHubIssue, Settings};
 use crate::services::{claude_session, git, github, settings as settings_service, tmux};
@@ -125,6 +125,14 @@ pub struct App {
     pub spinner_index: usize,
     pub last_issue_refresh: Instant,
     pub should_quit: bool,
+    /// Worktrees with a removal running in the background. Guards duplicate
+    /// removals, disables the Delete control, and holds quit until the results
+    /// are folded (an orphaned git child would remove the tree on disk after
+    /// the config was last saved).
+    pub removals_in_flight: std::collections::HashSet<Uuid>,
+    /// Quit was requested while removals were in flight; honoured when the
+    /// last one folds. A second request quits immediately.
+    pub quit_pending: bool,
 
     /// Clickable regions recorded by the renderers for the current frame.
     pub hits: Vec<Hit>,
@@ -205,6 +213,8 @@ impl App {
             spinner_index: 0,
             last_issue_refresh: Instant::now(),
             should_quit: false,
+            removals_in_flight: std::collections::HashSet::new(),
+            quit_pending: false,
             hits: Vec::new(),
             hovered: None,
             redraw: true,
@@ -228,6 +238,22 @@ impl App {
 
     pub fn title(&self) -> String {
         format!("forestui v{}", self.version)
+    }
+
+    /// Quit, unless a removal is still in flight — quitting then would orphan
+    /// the git child: it finishes removing the tree on disk, but the result is
+    /// never folded, so the saved config keeps a phantom entry. A second
+    /// request forces the quit anyway.
+    pub(super) fn request_quit(&mut self) {
+        if self.removals_in_flight.is_empty() || self.quit_pending {
+            self.should_quit = true;
+        } else {
+            self.quit_pending = true;
+            self.notify(
+                "Waiting for a worktree deletion to finish — press again to force quit",
+                Severity::Information,
+            );
+        }
     }
 
     // ------------------------------------------------------------------ startup
@@ -709,33 +735,47 @@ impl App {
     /// Fold a finished removal attempt. State changes only here — the confirm
     /// handler just spawns git, so a dirty refusal arrives with the entry (and
     /// the user's uncommitted work) fully intact.
-    fn on_worktree_remove_result(&mut self, worktree_id: Uuid, outcome: WorktreeRemoval) {
+    fn on_worktree_remove_result(
+        &mut self,
+        worktree_id: Uuid,
+        outcome: Result<git::RemoveOutcome, String>,
+    ) {
+        self.removals_in_flight.remove(&worktree_id);
+        // A quit that waited on this removal can go through now.
+        if self.quit_pending && self.removals_in_flight.is_empty() {
+            self.should_quit = true;
+        }
         // The entry may have been removed by other means while git ran.
         let Some((_, worktree)) = self.state.find_worktree(worktree_id) else {
             return;
         };
         let name = worktree.name.clone();
         match outcome {
-            WorktreeRemoval::Removed => {
+            Ok(git::RemoveOutcome::Removed) => {
                 self.state.remove_worktree(worktree_id);
                 self.rebuild_rows();
                 self.sync_sidebar_index();
                 self.reload_detail();
                 self.report_save_error();
             }
-            WorktreeRemoval::Dirty(summary) => {
+            Ok(git::RemoveOutcome::Dirty(summary)) => {
+                // The name is capped so the summary — the one thing the user
+                // needs before confirming — never clips off the dialog edge.
+                let display = crate::util::truncate(&name, 40);
                 self.modals.push(Modal::Confirm(
                     crate::modal::ConfirmModal::new(
                         "Uncommitted Changes",
                         format!(
-                            "'{name}' has uncommitted changes ({summary}).\nDeleting will discard them permanently."
+                            "'{display}' has uncommitted changes:\n{summary}\nDeleting will discard them permanently."
                         ),
                         crate::modal::ConfirmAction::ForceDeleteWorktree(worktree_id),
                     )
-                    .with_confirm_label("Delete anyway"),
+                    // Pushed by a background event, not a user action — a
+                    // keystroke already in the queue must not confirm it.
+                    .with_arm_delay(),
                 ));
             }
-            WorktreeRemoval::Failed(error) => {
+            Err(error) => {
                 self.notify(
                     format!("Could not delete '{name}': {error}"),
                     Severity::Error,
@@ -1019,7 +1059,7 @@ mod tests {
 
         app.handle_event(AppEvent::WorktreeRemoveResult {
             worktree_id,
-            outcome: WorktreeRemoval::Removed,
+            outcome: Ok(git::RemoveOutcome::Removed),
         });
         assert!(app.state.find_worktree(worktree_id).is_none());
     }
@@ -1032,19 +1072,36 @@ mod tests {
 
         app.handle_event(AppEvent::WorktreeRemoveResult {
             worktree_id,
-            outcome: WorktreeRemoval::Dirty("2 modified, 1 untracked".into()),
+            outcome: Ok(git::RemoveOutcome::Dirty("2 modified, 1 untracked".into())),
         });
 
         let Some(Modal::Confirm(confirm)) = app.modals.last() else {
             panic!("expected the second confirmation");
         };
         assert!(confirm.message.contains("2 modified, 1 untracked"));
-        assert_eq!(confirm.confirm_label, "Delete anyway");
+        assert_eq!(confirm.action.confirm_label(), "Delete anyway");
         assert!(matches!(
             confirm.action,
             crate::modal::ConfirmAction::ForceDeleteWorktree(id) if id == worktree_id
         ));
         // Nothing destroyed, nothing dropped from state.
+        assert!(app.state.find_worktree(worktree_id).is_some());
+
+        // Pushed by a background event: a keystroke already in flight when the
+        // modal appeared must not confirm it.
+        app.handle_key(key(KeyCode::Char('y')));
+        assert!(
+            matches!(app.modals.last(), Some(Modal::Confirm(_))),
+            "an unarmed confirm must swallow the stale 'y'"
+        );
+
+        if let Some(Modal::Confirm(confirm)) = app.modals.last_mut() {
+            confirm.disarm();
+        }
+        app.handle_key(key(KeyCode::Char('y')));
+        assert!(app.modals.is_empty());
+        // The forced removal is now in flight; the entry waits for the fold.
+        assert!(app.removals_in_flight.contains(&worktree_id));
         assert!(app.state.find_worktree(worktree_id).is_some());
     }
 
@@ -1056,12 +1113,57 @@ mod tests {
 
         app.handle_event(AppEvent::WorktreeRemoveResult {
             worktree_id,
-            outcome: WorktreeRemoval::Failed("worktree is locked".into()),
+            outcome: Err("worktree is locked".into()),
         });
 
         assert!(app.state.find_worktree(worktree_id).is_some());
         assert_eq!(app.notifications.len(), 1);
         assert!(app.notifications[0].text.contains("worktree is locked"));
+    }
+
+    #[tokio::test]
+    async fn delete_is_ignored_while_a_removal_is_in_flight() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("worktree selected");
+
+        app.removals_in_flight.insert(worktree_id);
+        app.handle_key(key(KeyCode::Char('d')));
+        assert!(
+            app.modals.is_empty(),
+            "no duplicate confirm while the removal runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn quit_waits_for_an_in_flight_removal() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("worktree selected");
+        app.removals_in_flight.insert(worktree_id);
+
+        app.handle_key(key(KeyCode::Char('q')));
+        assert!(!app.should_quit, "quit must wait for the fold");
+        assert!(app.quit_pending);
+
+        app.handle_event(AppEvent::WorktreeRemoveResult {
+            worktree_id,
+            outcome: Ok(git::RemoveOutcome::Removed),
+        });
+        assert!(app.should_quit, "the fold releases the pending quit");
+    }
+
+    #[tokio::test]
+    async fn a_second_quit_forces_out_past_an_in_flight_removal() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("worktree selected");
+        app.removals_in_flight.insert(worktree_id);
+
+        app.handle_key(key(KeyCode::Char('q')));
+        assert!(!app.should_quit);
+        app.handle_key(key(KeyCode::Char('q')));
+        assert!(app.should_quit);
     }
 
     #[tokio::test]
@@ -1593,7 +1695,7 @@ mod tests {
         assert!(app.state.find_worktree(worktree_id).is_some());
         app.handle_event(AppEvent::WorktreeRemoveResult {
             worktree_id,
-            outcome: WorktreeRemoval::Removed,
+            outcome: Ok(git::RemoveOutcome::Removed),
         });
         assert!(app.state.find_worktree(worktree_id).is_none());
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,7 +15,7 @@ pub use detail::{Action, DetailItem, Field};
 pub use keys::BINDINGS;
 pub use mouse::{Direction, Hit, HitTarget, ModalClick, ScrollbarGeom};
 
-use crate::event::{AppEvent, DetailMeta, EventTx, Severity};
+use crate::event::{AppEvent, DetailMeta, EventTx, Severity, WorktreeRemoval};
 use crate::modal::Modal;
 use crate::models::{ClaudeSession, GitHubIssue, Settings};
 use crate::services::{claude_session, git, github, settings as settings_service, tmux};
@@ -698,7 +698,49 @@ impl App {
                 self.reload_detail();
                 self.report_save_error();
             }
+            AppEvent::WorktreeRemoveResult {
+                worktree_id,
+                outcome,
+            } => self.on_worktree_remove_result(worktree_id, outcome),
             AppEvent::ReloadDetail => self.reload_detail(),
+        }
+    }
+
+    /// Fold a finished removal attempt. State changes only here — the confirm
+    /// handler just spawns git, so a dirty refusal arrives with the entry (and
+    /// the user's uncommitted work) fully intact.
+    fn on_worktree_remove_result(&mut self, worktree_id: Uuid, outcome: WorktreeRemoval) {
+        // The entry may have been removed by other means while git ran.
+        let Some((_, worktree)) = self.state.find_worktree(worktree_id) else {
+            return;
+        };
+        let name = worktree.name.clone();
+        match outcome {
+            WorktreeRemoval::Removed => {
+                self.state.remove_worktree(worktree_id);
+                self.rebuild_rows();
+                self.sync_sidebar_index();
+                self.reload_detail();
+                self.report_save_error();
+            }
+            WorktreeRemoval::Dirty(summary) => {
+                self.modals.push(Modal::Confirm(
+                    crate::modal::ConfirmModal::new(
+                        "Uncommitted Changes",
+                        format!(
+                            "'{name}' has uncommitted changes ({summary}).\nDeleting will discard them permanently."
+                        ),
+                        crate::modal::ConfirmAction::ForceDeleteWorktree(worktree_id),
+                    )
+                    .with_confirm_label("Delete anyway"),
+                ));
+            }
+            WorktreeRemoval::Failed(error) => {
+                self.notify(
+                    format!("Could not delete '{name}': {error}"),
+                    Severity::Error,
+                );
+            }
         }
     }
 
@@ -972,7 +1014,54 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('y')));
         assert!(app.modals.is_empty());
+        // Still there: the entry leaves state only when git reports success.
+        assert!(app.state.find_worktree(worktree_id).is_some());
+
+        app.handle_event(AppEvent::WorktreeRemoveResult {
+            worktree_id,
+            outcome: WorktreeRemoval::Removed,
+        });
         assert!(app.state.find_worktree(worktree_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn a_dirty_worktree_gets_a_second_confirmation() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("worktree selected");
+
+        app.handle_event(AppEvent::WorktreeRemoveResult {
+            worktree_id,
+            outcome: WorktreeRemoval::Dirty("2 modified, 1 untracked".into()),
+        });
+
+        let Some(Modal::Confirm(confirm)) = app.modals.last() else {
+            panic!("expected the second confirmation");
+        };
+        assert!(confirm.message.contains("2 modified, 1 untracked"));
+        assert_eq!(confirm.confirm_label, "Delete anyway");
+        assert!(matches!(
+            confirm.action,
+            crate::modal::ConfirmAction::ForceDeleteWorktree(id) if id == worktree_id
+        ));
+        // Nothing destroyed, nothing dropped from state.
+        assert!(app.state.find_worktree(worktree_id).is_some());
+    }
+
+    #[tokio::test]
+    async fn a_failed_removal_keeps_the_entry_and_reports() {
+        let (_dir, mut app) = app_with_fixture();
+        app.handle_key(key(KeyCode::Down));
+        let worktree_id = app.state.selection.worktree_id.expect("worktree selected");
+
+        app.handle_event(AppEvent::WorktreeRemoveResult {
+            worktree_id,
+            outcome: WorktreeRemoval::Failed("worktree is locked".into()),
+        });
+
+        assert!(app.state.find_worktree(worktree_id).is_some());
+        assert_eq!(app.notifications.len(), 1);
+        assert!(app.notifications[0].text.contains("worktree is locked"));
     }
 
     #[tokio::test]
@@ -1499,6 +1588,13 @@ mod tests {
         app.handle_mouse(click(12, 10));
 
         assert!(app.modals.is_empty());
+        // Removal is asynchronous now; the click only dispatches it. The entry
+        // goes when the git result is folded.
+        assert!(app.state.find_worktree(worktree_id).is_some());
+        app.handle_event(AppEvent::WorktreeRemoveResult {
+            worktree_id,
+            outcome: WorktreeRemoval::Removed,
+        });
         assert!(app.state.find_worktree(worktree_id).is_none());
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -101,23 +101,14 @@ pub enum AppEvent {
     WorktreeBranchRenamed { worktree_id: Uuid, branch: String },
     /// A worktree removal attempt finished. Success is folded into state on
     /// the main loop (single-writer, same reason as [`AppEvent::WorktreeAdded`]);
-    /// a dirty refusal opens the second confirmation; a failure surfaces git's
-    /// error and leaves the entry in place.
+    /// a dirty refusal opens the second confirmation; an error surfaces git's
+    /// message and leaves the entry in place.
     WorktreeRemoveResult {
         worktree_id: Uuid,
-        outcome: WorktreeRemoval,
+        outcome: Result<crate::services::git::RemoveOutcome, String>,
     },
     /// Reload the detail pane only.
     ReloadDetail,
-}
-
-/// How a worktree removal ended, as data for the fold to act on.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WorktreeRemoval {
-    Removed,
-    /// Refused: the tree holds uncommitted work (summary like "3 modified, 2 untracked").
-    Dirty(String),
-    Failed(String),
 }
 
 /// Clonable handle used by background tasks to push events back to the loop.

--- a/src/event.rs
+++ b/src/event.rs
@@ -99,8 +99,25 @@ pub enum AppEvent {
     /// config used to take the new name before `git branch -m` ran and keep it
     /// when the rename failed, leaving a branch recorded that does not exist.
     WorktreeBranchRenamed { worktree_id: Uuid, branch: String },
+    /// A worktree removal attempt finished. Success is folded into state on
+    /// the main loop (single-writer, same reason as [`AppEvent::WorktreeAdded`]);
+    /// a dirty refusal opens the second confirmation; a failure surfaces git's
+    /// error and leaves the entry in place.
+    WorktreeRemoveResult {
+        worktree_id: Uuid,
+        outcome: WorktreeRemoval,
+    },
     /// Reload the detail pane only.
     ReloadDetail,
+}
+
+/// How a worktree removal ended, as data for the fold to act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeRemoval {
+    Removed,
+    /// Refused: the tree holds uncommitted work (summary like "3 modified, 2 untracked").
+    Dirty(String),
+    Failed(String),
 }
 
 /// Clonable handle used by background tasks to push events back to the loop.

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -55,6 +55,8 @@ pub enum ModalEffect {
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     DeleteWorktree(Uuid),
+    /// Second-step confirm: the worktree was seen to hold uncommitted work.
+    ForceDeleteWorktree(Uuid),
     RemoveRepository(Uuid),
 }
 
@@ -1091,6 +1093,9 @@ impl EditButtonModal {
 pub struct ConfirmModal {
     pub title: String,
     pub message: String,
+    /// Label on the destructive button — "Delete", or something more explicit
+    /// when the confirmation is about losing work rather than tidying up.
+    pub confirm_label: String,
     pub action: ConfirmAction,
     /// `true` when the destructive choice is highlighted.
     pub confirm_focused: bool,
@@ -1105,9 +1110,15 @@ impl ConfirmModal {
         Self {
             title: title.into(),
             message: message.into(),
+            confirm_label: "Delete".into(),
             action,
             confirm_focused: false,
         }
+    }
+
+    pub fn with_confirm_label(mut self, label: impl Into<String>) -> Self {
+        self.confirm_label = label.into();
+        self
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome {

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -60,6 +60,18 @@ pub enum ConfirmAction {
     RemoveRepository(Uuid),
 }
 
+impl ConfirmAction {
+    /// Label on the destructive button. Derived from the action so a
+    /// construction site cannot pair a discard-your-work action with a bland
+    /// "Delete" button.
+    pub fn confirm_label(&self) -> &'static str {
+        match self {
+            ConfirmAction::ForceDeleteWorktree(_) => "Delete anyway",
+            ConfirmAction::DeleteWorktree(_) | ConfirmAction::RemoveRepository(_) => "Delete",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ModalResult {
     RepositoryAdded {
@@ -1093,13 +1105,19 @@ impl EditButtonModal {
 pub struct ConfirmModal {
     pub title: String,
     pub message: String,
-    /// Label on the destructive button — "Delete", or something more explicit
-    /// when the confirmation is about losing work rather than tidying up.
-    pub confirm_label: String,
     pub action: ConfirmAction,
     /// `true` when the destructive choice is highlighted.
     pub confirm_focused: bool,
+    /// Submit keys are ignored until this instant. Set on confirms pushed by a
+    /// *background event*: a keystroke queued before the modal appeared (a `y`
+    /// aimed at ClaudeYolo, letters typed into the modal underneath) must not
+    /// confirm a dialog the user never saw. Cancel always works.
+    armed_at: Option<std::time::Instant>,
 }
+
+/// Long enough to outlive any keystroke already in the event queue, far too
+/// short for a human deliberately confirming to notice.
+const CONFIRM_ARM_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
 
 impl ConfirmModal {
     pub fn new(
@@ -1110,15 +1128,26 @@ impl ConfirmModal {
         Self {
             title: title.into(),
             message: message.into(),
-            confirm_label: "Delete".into(),
             action,
             confirm_focused: false,
+            armed_at: None,
         }
     }
 
-    pub fn with_confirm_label(mut self, label: impl Into<String>) -> Self {
-        self.confirm_label = label.into();
+    /// For confirms pushed by a background event rather than a user action.
+    pub fn with_arm_delay(mut self) -> Self {
+        self.armed_at = Some(std::time::Instant::now() + CONFIRM_ARM_DELAY);
         self
+    }
+
+    #[cfg(test)]
+    pub fn disarm(&mut self) {
+        self.armed_at = None;
+    }
+
+    fn submit_armed(&self) -> bool {
+        self.armed_at
+            .is_none_or(|at| std::time::Instant::now() >= at)
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome {
@@ -1131,14 +1160,20 @@ impl ConfirmModal {
                 ModalOutcome::None
             }
             KeyCode::Char('y') | KeyCode::Char('Y') => {
-                ModalOutcome::Submit(ModalResult::Confirmed(self.action.clone()))
+                if self.submit_armed() {
+                    ModalOutcome::Submit(ModalResult::Confirmed(self.action.clone()))
+                } else {
+                    ModalOutcome::None
+                }
             }
             KeyCode::Char('n') | KeyCode::Char('N') => ModalOutcome::Close,
             KeyCode::Enter => {
-                if self.confirm_focused {
+                if self.confirm_focused && self.submit_armed() {
                     ModalOutcome::Submit(ModalResult::Confirmed(self.action.clone()))
-                } else {
+                } else if !self.confirm_focused {
                     ModalOutcome::Close
+                } else {
+                    ModalOutcome::None
                 }
             }
             _ => ModalOutcome::None,

--- a/src/services/git.rs
+++ b/src/services/git.rs
@@ -200,21 +200,71 @@ pub async fn create_worktree(
     Ok(())
 }
 
-/// Remove a worktree, retrying with `--force` once if the plain remove fails.
-pub async fn remove_worktree(repo_path: &str, worktree_path: &str) -> GitResult<()> {
+/// What a plain (non-forced) removal attempt decided.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoveOutcome {
+    Removed,
+    /// git refused because the tree holds uncommitted work. The summary is
+    /// human-readable, e.g. "3 modified, 2 untracked".
+    Dirty(String),
+}
+
+/// Remove a worktree without destroying uncommitted work.
+///
+/// `git worktree remove` refuses for one recoverable reason — the tree holds
+/// uncommitted changes or untracked files. That refusal is a safety check, so
+/// it is surfaced as [`RemoveOutcome::Dirty`] for the caller to confirm rather
+/// than papered over with `--force`. Any other refusal (missing directory,
+/// stale metadata) is retried with `--force`, which is what a stale entry
+/// legitimately needs.
+pub async fn remove_worktree(repo_path: &str, worktree_path: &str) -> GitResult<RemoveOutcome> {
     let repo = expand(repo_path);
     let wt = expand(worktree_path).to_string_lossy().to_string();
 
     let (code, _out, _err) = run_git(&["worktree", "remove", wt.as_str()], Some(&repo)).await?;
     if code == 0 {
-        return Ok(());
+        return Ok(RemoveOutcome::Removed);
     }
+    // Ask the tree itself instead of parsing stderr, whose wording is not a
+    // stable interface across git versions.
+    if let Some(summary) = status_summary(&expand(worktree_path)).await {
+        return Ok(RemoveOutcome::Dirty(summary));
+    }
+    force_remove_worktree(repo_path, worktree_path).await?;
+    Ok(RemoveOutcome::Removed)
+}
+
+/// Remove a worktree discarding whatever is in it. Only for after the user has
+/// seen what they are about to lose (or the tree is already unreadable).
+pub async fn force_remove_worktree(repo_path: &str, worktree_path: &str) -> GitResult<()> {
+    let repo = expand(repo_path);
+    let wt = expand(worktree_path).to_string_lossy().to_string();
     let (code, _out, stderr) =
         run_git(&["worktree", "remove", "--force", wt.as_str()], Some(&repo)).await?;
     if code != 0 {
         return Err(GitError(format!("Failed to remove worktree: {stderr}")));
     }
     Ok(())
+}
+
+/// "N modified, M untracked" when the tree holds uncommitted work; `None` when
+/// it is clean — or unreadable (deleted directory), which the caller treats as
+/// "nothing left to lose".
+async fn status_summary(dir: &Path) -> Option<String> {
+    let (code, stdout, _stderr) = run_git(&["status", "--porcelain"], Some(dir)).await.ok()?;
+    if code != 0 || stdout.is_empty() {
+        return None;
+    }
+    let untracked = stdout.lines().filter(|l| l.starts_with("??")).count();
+    let modified = stdout.lines().count() - untracked;
+    let mut parts = Vec::new();
+    if modified > 0 {
+        parts.push(format!("{modified} modified"));
+    }
+    if untracked > 0 {
+        parts.push(format!("{untracked} untracked"));
+    }
+    Some(parts.join(", "))
 }
 
 pub async fn rename_branch(path: &str, old_name: &str, new_name: &str) -> GitResult<()> {
@@ -479,10 +529,65 @@ mod tests {
         let listed = list_worktrees(&repo_str).await.unwrap();
         assert_eq!(listed.len(), 2);
 
-        remove_worktree(&repo_str, &wt.to_string_lossy())
+        let outcome = remove_worktree(&repo_str, &wt.to_string_lossy())
+            .await
+            .unwrap();
+        assert_eq!(outcome, RemoveOutcome::Removed);
+        assert!(!wt.exists());
+    }
+
+    #[tokio::test]
+    async fn a_dirty_worktree_is_refused_with_a_summary_not_destroyed() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_repo(&repo);
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let wt = dir.path().join("wt-dirty");
+        create_worktree(&repo_str, &wt, "feat/dirty", true, None)
+            .await
+            .unwrap();
+        std::fs::write(wt.join("tracked.txt"), "committed").unwrap();
+        git_in(&wt, &["add", "tracked.txt"]);
+        git_in(&wt, &["commit", "-m", "add tracked"]);
+        std::fs::write(wt.join("tracked.txt"), "edited but not committed").unwrap();
+        std::fs::write(wt.join("scratch.txt"), "untracked").unwrap();
+
+        let outcome = remove_worktree(&repo_str, &wt.to_string_lossy())
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            RemoveOutcome::Dirty("1 modified, 1 untracked".into())
+        );
+        // The refusal left the work in place.
+        assert!(wt.join("scratch.txt").exists());
+
+        force_remove_worktree(&repo_str, &wt.to_string_lossy())
             .await
             .unwrap();
         assert!(!wt.exists());
+    }
+
+    #[tokio::test]
+    async fn a_worktree_with_a_deleted_directory_is_removed_without_a_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_repo(&repo);
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let wt = dir.path().join("wt-gone");
+        create_worktree(&repo_str, &wt, "feat/gone", true, None)
+            .await
+            .unwrap();
+        std::fs::remove_dir_all(&wt).unwrap();
+
+        // A stale entry must not read as "dirty" — it force-removes silently.
+        let outcome = remove_worktree(&repo_str, &wt.to_string_lossy())
+            .await
+            .unwrap();
+        assert_eq!(outcome, RemoveOutcome::Removed);
+        assert_eq!(list_worktrees(&repo_str).await.unwrap().len(), 1);
     }
 
     /// Run git in `dir`, panicking with the argv on failure. Tests only.

--- a/src/services/git.rs
+++ b/src/services/git.rs
@@ -211,60 +211,146 @@ pub enum RemoveOutcome {
 
 /// Remove a worktree without destroying uncommitted work.
 ///
-/// `git worktree remove` refuses for one recoverable reason — the tree holds
-/// uncommitted changes or untracked files. That refusal is a safety check, so
-/// it is surfaced as [`RemoveOutcome::Dirty`] for the caller to confirm rather
-/// than papered over with `--force`. Any other refusal (missing directory,
-/// stale metadata) is retried with `--force`, which is what a stale entry
-/// legitimately needs.
+/// `git worktree remove` refuses a tree with uncommitted changes or untracked
+/// files. That refusal is a safety check, so it is surfaced as
+/// [`RemoveOutcome::Dirty`] for the caller to confirm rather than papered over
+/// with `--force`. `--force` runs only when there is provably nothing to lose:
+/// the directory is already gone, or `git status` read the tree and found it
+/// clean (a clean tree can still be refused, e.g. when it contains a
+/// submodule). A tree whose status *cannot* be read is an error, not a force —
+/// resolving that ambiguity in the destructive direction is the exact bug this
+/// function exists to prevent. A locked worktree is also an error: git wants
+/// `--force --force` for those, and offering "delete anyway" only to fail on
+/// the lock would mislead.
 pub async fn remove_worktree(repo_path: &str, worktree_path: &str) -> GitResult<RemoveOutcome> {
     let repo = expand(repo_path);
-    let wt = expand(worktree_path).to_string_lossy().to_string();
+    let wt_dir = expand(worktree_path);
+    let wt = wt_dir.to_string_lossy().to_string();
 
     let (code, _out, _err) = run_git(&["worktree", "remove", wt.as_str()], Some(&repo)).await?;
     if code == 0 {
         return Ok(RemoveOutcome::Removed);
     }
+
+    if worktree_entry(&repo, &wt_dir).await == Some(WorktreeEntry::Locked) {
+        return Err(GitError(
+            "worktree is locked — unlock it first (git worktree unlock)".into(),
+        ));
+    }
+
     // Ask the tree itself instead of parsing stderr, whose wording is not a
     // stable interface across git versions.
-    if let Some(summary) = status_summary(&expand(worktree_path)).await {
-        return Ok(RemoveOutcome::Dirty(summary));
+    if wt_dir.exists() {
+        match tree_state(&wt_dir).await {
+            TreeState::Dirty(summary) => return Ok(RemoveOutcome::Dirty(summary)),
+            TreeState::Clean => {}
+            TreeState::Unreadable(reason) => {
+                return Err(GitError(format!(
+                    "cannot verify the worktree is clean: {reason}"
+                )));
+            }
+        }
     }
     force_remove_worktree(repo_path, worktree_path).await?;
     Ok(RemoveOutcome::Removed)
 }
 
 /// Remove a worktree discarding whatever is in it. Only for after the user has
-/// seen what they are about to lose (or the tree is already unreadable).
+/// seen what they are about to lose (or there is provably nothing to lose).
 pub async fn force_remove_worktree(repo_path: &str, worktree_path: &str) -> GitResult<()> {
     let repo = expand(repo_path);
-    let wt = expand(worktree_path).to_string_lossy().to_string();
+    let wt_dir = expand(worktree_path);
+    let wt = wt_dir.to_string_lossy().to_string();
     let (code, _out, stderr) =
         run_git(&["worktree", "remove", "--force", wt.as_str()], Some(&repo)).await?;
-    if code != 0 {
-        return Err(GitError(format!("Failed to remove worktree: {stderr}")));
+    if code == 0 {
+        return Ok(());
     }
-    Ok(())
+    // A pruned or gc'd entry fails even `--force` ("is not a working tree").
+    // When git no longer knows the path and the directory is gone there is
+    // nothing left to remove — failing here would strand the entry in the
+    // sidebar with no way to ever delete it.
+    if !wt_dir.exists() && worktree_entry(&repo, &wt_dir).await.is_none() {
+        return Ok(());
+    }
+    Err(GitError(format!("Failed to remove worktree: {stderr}")))
 }
 
-/// "N modified, M untracked" when the tree holds uncommitted work; `None` when
-/// it is clean — or unreadable (deleted directory), which the caller treats as
-/// "nothing left to lose".
-async fn status_summary(dir: &Path) -> Option<String> {
-    let (code, stdout, _stderr) = run_git(&["status", "--porcelain"], Some(dir)).await.ok()?;
-    if code != 0 || stdout.is_empty() {
+/// What `git status` said about a tree that refused a plain removal.
+enum TreeState {
+    Clean,
+    /// Summary like "3 modified, 2 untracked".
+    Dirty(String),
+    /// Status could not be read (dubious ownership, corrupt index, spawn
+    /// failure) — the tree cannot be assumed clean.
+    Unreadable(String),
+}
+
+async fn tree_state(dir: &Path) -> TreeState {
+    // `--ignore-submodules=none`: without it a dirty submodule reads as clean,
+    // and clean is the destructive direction here. git's own pre-removal
+    // cleanliness check passes the same flag.
+    let args = ["status", "--porcelain", "--ignore-submodules=none"];
+    match run_git(&args, Some(dir)).await {
+        Ok((0, stdout, _)) if stdout.is_empty() => TreeState::Clean,
+        Ok((0, stdout, _)) => {
+            let untracked = stdout.lines().filter(|l| l.starts_with("??")).count();
+            let modified = stdout.lines().count() - untracked;
+            let mut parts = Vec::new();
+            if modified > 0 {
+                parts.push(format!("{modified} modified"));
+            }
+            if untracked > 0 {
+                parts.push(format!("{untracked} untracked"));
+            }
+            TreeState::Dirty(parts.join(", "))
+        }
+        Ok((_, _, stderr)) => TreeState::Unreadable(stderr),
+        Err(error) => TreeState::Unreadable(error.to_string()),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorktreeEntry {
+    Listed,
+    Locked,
+}
+
+/// Whether `git worktree list` knows the given directory, and whether it is
+/// locked. `None` when git does not list it (or the list itself failed, which
+/// callers must treat as "unknown", never as permission to force).
+async fn worktree_entry(repo: &Path, wt_dir: &Path) -> Option<WorktreeEntry> {
+    let (code, stdout, _err) = run_git(&["worktree", "list", "--porcelain"], Some(repo))
+        .await
+        .ok()?;
+    if code != 0 {
         return None;
     }
-    let untracked = stdout.lines().filter(|l| l.starts_with("??")).count();
-    let modified = stdout.lines().count() - untracked;
-    let mut parts = Vec::new();
-    if modified > 0 {
-        parts.push(format!("{modified} modified"));
+    let target = std::fs::canonicalize(wt_dir).unwrap_or_else(|_| wt_dir.to_path_buf());
+    for block in stdout.split("\n\n") {
+        let mut path: Option<&str> = None;
+        let mut locked = false;
+        for line in block.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("worktree ") {
+                path = Some(rest);
+            } else if line == "locked" || line.starts_with("locked ") {
+                locked = true;
+            }
+        }
+        if let Some(p) = path {
+            let p = Path::new(p);
+            let p = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+            if p == target {
+                return Some(if locked {
+                    WorktreeEntry::Locked
+                } else {
+                    WorktreeEntry::Listed
+                });
+            }
+        }
     }
-    if untracked > 0 {
-        parts.push(format!("{untracked} untracked"));
-    }
-    Some(parts.join(", "))
+    None
 }
 
 pub async fn rename_branch(path: &str, old_name: &str, new_name: &str) -> GitResult<()> {
@@ -567,6 +653,30 @@ mod tests {
             .await
             .unwrap();
         assert!(!wt.exists());
+    }
+
+    #[tokio::test]
+    async fn a_locked_worktree_is_refused_with_an_unlock_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_repo(&repo);
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let wt = dir.path().join("wt-locked");
+        create_worktree(&repo_str, &wt, "feat/locked", true, None)
+            .await
+            .unwrap();
+        git_in(&repo, &["worktree", "lock", &wt.to_string_lossy()]);
+
+        // Even a *dirty* locked tree must not reach the "Delete anyway"
+        // prompt: git wants `--force --force` for locks, which the app never
+        // passes, so confirming would fail with an unrelated lock error.
+        std::fs::write(wt.join("scratch.txt"), "untracked").unwrap();
+        let error = remove_worktree(&repo_str, &wt.to_string_lossy())
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("locked"), "got: {error}");
+        assert!(wt.join("scratch.txt").exists());
     }
 
     #[tokio::test]

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -950,7 +950,7 @@ fn confirm(frame: &mut Frame, modal: &ConfirmModal, area: Rect, hits: &mut Hits)
         vec![
             control("Cancel", !modal.confirm_focused, theme::Variant::Normal, 0),
             control(
-                "Delete",
+                &modal.confirm_label,
                 modal.confirm_focused,
                 theme::Variant::Destructive,
                 1,

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -950,7 +950,7 @@ fn confirm(frame: &mut Frame, modal: &ConfirmModal, area: Rect, hits: &mut Hits)
         vec![
             control("Cancel", !modal.confirm_focused, theme::Variant::Normal, 0),
             control(
-                &modal.confirm_label,
+                modal.action.confirm_label(),
                 modal.confirm_focused,
                 theme::Variant::Destructive,
                 1,


### PR DESCRIPTION
## What

`git worktree remove` refuses a dirty tree, and the automatic `--force` retry defeated that safety check: deleting a worktree from the UI discarded uncommitted changes with no warning and nothing to recover from.

Now:

- The plain remove runs first. When git refuses because the tree holds uncommitted work, a **second confirmation** opens showing a status summary ("1 modified, 2 untracked") behind an explicit **Delete anyway** button.
- A clean tree — or one whose directory is already gone (stale entry) — still removes silently with a single confirmation, as before. Dirtiness is determined by asking `git status --porcelain` in the tree itself, not by parsing stderr.
- State no longer drops the entry before git answers. Removal is folded on the main loop via a new `AppEvent::WorktreeRemoveResult` when git reports success, so a refusal keeps the worktree and its contents fully intact.
- A genuine removal failure (e.g. locked worktree) now keeps the entry and surfaces git's error as a notification, replacing the old silent drop-from-state.

## Testing

- `make check` green; new unit tests: dirty refusal with summary, deleted-directory silent force-removal, dirty→second-confirm fold, failed-removal keeps entry + notification.
- tu-verified end to end: dirty worktree → d → confirm → second modal with summary → Cancel preserves files; Delete anyway removes; clean worktree deletes with a single confirm and no second modal.

Closes #27