### PR TITLE
Harden the self-update: verify checksums, stage per-process, time out, speak up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,15 +184,23 @@ itself rather than whatever `forestui` happens to be on `PATH`.
 ### Self-update
 forestui keeps itself current the way the Python build did — automatically, on
 launch — but never on the UI thread. `App::check_for_update` spawns the check
-once the terminal is up, and the only visible result is a notification after a
-new version is already in place.
+once the terminal is up. Success shows one notification after the new version
+is already in place; network failures (offline, a download that dropped, a
+release whose assets have not finished uploading) stay silent and retry next
+launch. Only a *persistent local* failure — an unwritable install dir — shows
+an error notification, and is remembered in the version cache
+(`install_failed`) so the multi-MB download is not re-spent on every launch
+while it would fail identically.
 
 What it does depends on how the binary got there:
 
 - **From a GitHub release** — built with `--features binary-release`, so it
-  downloads the asset for its platform and renames it over `current_exe()`.
-  Replacing the file under a running process is safe on Unix; the new build
-  takes effect on the next launch.
+  downloads the asset for its platform, verifies it against the published
+  `.sha256` (no checksum, no update — release assets **must** ship their
+  checksums), and atomically swaps it over `current_exe()` via the same
+  fsync-then-rename writer the config files use. Replacing the file under a
+  running process is safe on Unix; the new build takes effect on the next
+  launch.
 - **From `cargo install`** — the feature is off, so it only reports that a newer
   version exists. Recompiling a crate underneath a running TUI is not something
   to do unasked.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "shlex 1.3.0",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ ratatui = "0.30.2"
 # dependency, which is what lets the musl release targets link statically.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 semver = "1"
+# Verifying the downloaded release binary against its published .sha256.
+sha2 = "0.10"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 shlex = "1.3.0"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -282,19 +282,30 @@ impl App {
     ///
     /// Deliberately fire-and-forget on a background task: the UI is already up
     /// by the time this runs, so a slow or unreachable GitHub costs nothing but
-    /// a notification that never arrives. Failures are silent for the same
-    /// reason — being offline is the common case, and it is not the user's
-    /// problem to solve mid-session.
+    /// a notification that never arrives. Being offline stays silent — it is
+    /// the common case and not the user's problem to solve mid-session — but a
+    /// *persistent* install failure (an unwritable install dir) is theirs to
+    /// fix and surfaces once per launch.
     fn check_for_update(&self) {
         let tx = self.tx.clone();
         tokio::spawn(async move {
-            if let Ok(Some(version)) = crate::version_check::update_if_stale().await {
-                let message = if crate::version_check::installs_in_place() {
-                    format!("forestui v{version} installed — restart to use it")
-                } else {
-                    format!("forestui v{version} is available — `cargo install forestui`")
-                };
-                tx.notify(message, Severity::Information);
+            use crate::version_check::UpdateStatus;
+            match crate::version_check::update_if_stale().await {
+                UpdateStatus::Silent => {}
+                UpdateStatus::Installed(version) => tx.notify(
+                    format!("forestui v{version} installed — restart to use it"),
+                    Severity::Information,
+                ),
+                UpdateStatus::Available(version) => tx.notify(
+                    format!("forestui v{version} is available — `cargo install forestui`"),
+                    Severity::Information,
+                ),
+                UpdateStatus::InstallFailed { version, reason } => tx.notify(
+                    format!(
+                        "forestui v{version} is available but could not be installed: {reason}"
+                    ),
+                    Severity::Error,
+                ),
             }
         });
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -289,23 +289,9 @@ impl App {
     fn check_for_update(&self) {
         let tx = self.tx.clone();
         tokio::spawn(async move {
-            use crate::version_check::UpdateStatus;
-            match crate::version_check::update_if_stale().await {
-                UpdateStatus::Silent => {}
-                UpdateStatus::Installed(version) => tx.notify(
-                    format!("forestui v{version} installed — restart to use it"),
-                    Severity::Information,
-                ),
-                UpdateStatus::Available(version) => tx.notify(
-                    format!("forestui v{version} is available — `cargo install forestui`"),
-                    Severity::Information,
-                ),
-                UpdateStatus::InstallFailed { version, reason } => tx.notify(
-                    format!(
-                        "forestui v{version} is available but could not be installed: {reason}"
-                    ),
-                    Severity::Error,
-                ),
+            let status = crate::version_check::update_if_stale().await;
+            if let Some((message, severity)) = status.notification() {
+                tx.notify(message, severity);
             }
         });
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -185,6 +185,20 @@ pub fn exit_code(status: std::process::ExitStatus, sentinel: i32) -> i32 {
 ///   leaving the empty file that loads as empty state — the exact loss this
 ///   function exists to prevent.
 pub fn write_atomically(path: &Path, contents: &str) -> std::io::Result<()> {
+    write_bytes_atomically(path, contents.as_bytes(), None)
+}
+
+/// [`write_atomically`] for binary content, with an optional mode floor.
+///
+/// `executable_mode` is applied when the target does not exist or is not
+/// owner-executable — the self-updater passes `0o755` so the replacement
+/// binary always comes out runnable, while a deliberately tightened install
+/// (say 0o700) keeps its exact mode rather than being widened.
+pub fn write_bytes_atomically(
+    path: &Path,
+    contents: &[u8],
+    executable_mode: Option<u32>,
+) -> std::io::Result<()> {
     // Resolve the link before choosing a sibling, so both the temp file and the
     // rename land in the directory that actually holds the data.
     let target = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
@@ -197,7 +211,7 @@ pub fn write_atomically(path: &Path, contents: &str) -> std::io::Result<()> {
     name.push_str(&format!(".tmp-{}", std::process::id()));
     temp.set_file_name(name);
 
-    let result = write_temp_then_rename(&temp, &target, contents);
+    let result = write_temp_then_rename(&temp, &target, contents, executable_mode);
     if result.is_err() {
         // Leave no half-written sibling behind; the original is untouched.
         let _ = std::fs::remove_file(&temp);
@@ -205,20 +219,44 @@ pub fn write_atomically(path: &Path, contents: &str) -> std::io::Result<()> {
     result
 }
 
-/// The fallible half of [`write_atomically`], split out so one cleanup on the
-/// error path covers a failure at any step rather than only at the rename.
-fn write_temp_then_rename(temp: &Path, target: &Path, contents: &str) -> std::io::Result<()> {
+/// The fallible half of [`write_bytes_atomically`], split out so one cleanup on
+/// the error path covers a failure at any step rather than only at the rename.
+fn write_temp_then_rename(
+    temp: &Path,
+    target: &Path,
+    contents: &[u8],
+    executable_mode: Option<u32>,
+) -> std::io::Result<()> {
     use std::io::Write;
 
     let mut file = std::fs::File::create(temp)?;
-    file.write_all(contents.as_bytes())?;
+    file.write_all(contents)?;
     // Durability before visibility: the rename is only atomic for readers, not
     // for the disk.
     file.sync_all()?;
     drop(file);
 
-    if let Ok(existing) = std::fs::metadata(target) {
-        std::fs::set_permissions(temp, existing.permissions())?;
+    let existing = std::fs::metadata(target).ok().map(|m| m.permissions());
+    #[cfg(unix)]
+    let permissions = {
+        use std::os::unix::fs::PermissionsExt;
+        match (existing, executable_mode) {
+            // The caller wants the file runnable and the current mode is not.
+            (Some(p), Some(mode)) if p.mode() & 0o100 == 0 => {
+                Some(std::fs::Permissions::from_mode(mode))
+            }
+            (Some(p), _) => Some(p),
+            (None, Some(mode)) => Some(std::fs::Permissions::from_mode(mode)),
+            (None, None) => None,
+        }
+    };
+    #[cfg(not(unix))]
+    let permissions = {
+        let _ = executable_mode;
+        existing
+    };
+    if let Some(permissions) = permissions {
+        std::fs::set_permissions(temp, permissions)?;
     }
 
     std::fs::rename(temp, target)?;

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -55,6 +55,19 @@ pub fn is_newer(current: &str, latest: &str) -> bool {
 struct VersionCache {
     checked_at: u64,
     latest_version: String,
+    /// Set when downloading or installing `latest_version` failed after a
+    /// successful lookup. Remembered so the next launch does not re-spend the
+    /// multi-MB download on a failure that will repeat (an unwritable install
+    /// dir fails identically every time); cleared by expiry, a newer release,
+    /// or a successful install.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    install_failed: Option<InstallFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InstallFailure {
+    version: String,
+    reason: String,
 }
 
 fn cache_path() -> PathBuf {
@@ -102,6 +115,7 @@ pub async fn latest_version() -> Option<String> {
             write_cache(&VersionCache {
                 checked_at: now_secs(),
                 latest_version: version.clone(),
+                install_failed: None,
             });
             Some(version)
         }
@@ -113,7 +127,15 @@ pub async fn latest_version() -> Option<String> {
 
 async fn fetch_latest_version() -> Result<String> {
     let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
-    let body: serde_json::Value = reqwest::Client::new()
+    // Without a timeout, a network that accepts the connection but never
+    // answers parks this task forever — and with it the whole check, since a
+    // hung lookup is cached by nobody.
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("could not build the HTTP client")?;
+    let body: serde_json::Value = client
         .get(&url)
         .header("User-Agent", USER_AGENT)
         .send()
@@ -156,13 +178,23 @@ pub fn release_asset_url(version: &str) -> Result<String> {
     ))
 }
 
-/// Download `url` and put it at `target`, atomically.
+/// Download `url`, verify it against its published `.sha256`, and put it at
+/// `target`, atomically.
 ///
-/// Staged beside the target and renamed into place, so the swap is atomic and a
-/// half-downloaded file can never end up executable. Replacing the file under a
-/// running process is safe on Unix — the running image is already mapped — which
-/// is why this can happen while the UI is up, with the new build taking effect
-/// on the next launch.
+/// The release workflow publishes a checksum beside every asset and
+/// `install.sh` verifies it; the updater holds itself to the same standard —
+/// stricter, in fact: a missing or malformed checksum aborts the update rather
+/// than trusting whatever arrived over the wire, because the updater lives
+/// inside the binary it would break and the user cannot self-recover from a
+/// corrupt install.
+///
+/// Staged beside the target under a per-process name and renamed into place, so
+/// the swap is atomic, a half-downloaded file can never end up executable, and
+/// two instances updating at once cannot rename each other's half-written
+/// staging file over the real binary. Replacing the file under a running
+/// process is safe on Unix — the running image is already mapped — which is why
+/// this can happen while the UI is up, with the new build taking effect on the
+/// next launch.
 ///
 /// Takes its URL and destination rather than deriving them, so the download and
 /// the swap can be tested against a local server and a temporary file. Deciding
@@ -170,7 +202,13 @@ pub fn release_asset_url(version: &str) -> Result<String> {
 /// `binary-release` gate.
 #[cfg(any(feature = "binary-release", test))]
 pub(crate) async fn install_from(url: &str, target: &std::path::Path) -> Result<()> {
-    let bytes = reqwest::Client::new()
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(90))
+        .build()
+        .context("could not build the HTTP client")?;
+
+    let bytes = client
         .get(url)
         .header("User-Agent", USER_AGENT)
         .send()
@@ -182,62 +220,168 @@ pub(crate) async fn install_from(url: &str, target: &std::path::Path) -> Result<
         .await
         .context("could not read the downloaded release")?;
 
-    let staged = target.with_extension("tmp-update");
-    tokio::fs::write(&staged, &bytes)
+    // Verify before anything touches disk.
+    let checksum_body = client
+        .get(format!("{url}.sha256"))
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .context("could not fetch the release checksum")?
+        .error_for_status()
+        .context("the release has no checksum")?
+        .text()
+        .await
+        .context("could not read the release checksum")?;
+    // Coreutils format: `<64 hex>  <filename>`. Only the hash is trusted.
+    let expected = checksum_body
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+        anyhow::bail!("the release checksum file is malformed");
+    }
+    use sha2::Digest;
+    let actual = format!("{:x}", sha2::Sha256::digest(&bytes));
+    if actual != expected {
+        anyhow::bail!("the downloaded release does not match its checksum");
+    }
+
+    let staged = staging_path(target);
+    // All the fallible steps live in one helper so every failure path — write,
+    // chmod, rename — cleans the staged file up rather than leaving a stray
+    // binary beside the real one. Same contract as `util::write_atomically`.
+    let result = write_staged_then_rename(&staged, target, &bytes).await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&staged).await;
+    }
+    result
+}
+
+/// Sibling of `target` with a per-process suffix, so concurrent instances
+/// stage privately: the last rename wins whole-file, which is fine — both
+/// downloaded (and verified) the same asset.
+#[cfg(any(feature = "binary-release", test))]
+fn staging_path(target: &std::path::Path) -> PathBuf {
+    let mut name = target.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".tmp-update-{}", std::process::id()));
+    target.with_file_name(name)
+}
+
+#[cfg(any(feature = "binary-release", test))]
+async fn write_staged_then_rename(
+    staged: &std::path::Path,
+    target: &std::path::Path,
+    bytes: &[u8],
+) -> Result<()> {
+    tokio::fs::write(staged, bytes)
         .await
         .context("could not write the downloaded release")?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+        tokio::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o755))
             .await
             .context("could not mark the downloaded release executable")?;
     }
 
-    // A rename across filesystems fails, so clean the staged file up rather than
-    // leaving a stray binary beside the real one.
-    if let Err(error) = tokio::fs::rename(&staged, target).await {
-        let _ = tokio::fs::remove_file(&staged).await;
-        return Err(error).context("could not replace the running binary");
-    }
+    tokio::fs::rename(staged, target)
+        .await
+        .context("could not replace the running binary")?;
     Ok(())
 }
 
-/// Bring the installed binary up to date, returning the version involved.
+/// What the startup update check concluded.
 ///
-/// `Ok(None)` means there was nothing to do: already current, a source build, or
-/// no answer from GitHub.
-pub async fn update_if_stale() -> Result<Option<String>> {
+/// The enum is the cfg-independent contract: which variants a build actually
+/// constructs depends on the `binary-release` gate (`Installed`/`InstallFailed`
+/// with it, `Available` without), so each side sees the others as dead.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// Nothing to say: already current, a source build, or no answer from
+    /// GitHub. Being offline is the common case, not the user's problem.
+    Silent,
+    /// The new build is already in place; takes effect on the next launch.
+    Installed(String),
+    /// A newer version exists. Installed by cargo, so replacing the binary in
+    /// place would be undone by the next `cargo install`, and recompiling the
+    /// crate underneath a running TUI is not something to do unasked.
+    Available(String),
+    /// A newer version exists but could not be installed. Unlike being
+    /// offline, this is actionable (an unwritable install dir, a corrupted
+    /// mirror) and would otherwise repeat invisibly on every launch.
+    InstallFailed { version: String, reason: String },
+}
+
+/// Bring the installed binary up to date.
+pub async fn update_if_stale() -> UpdateStatus {
     if is_dev_build() {
-        return Ok(None);
+        return UpdateStatus::Silent;
     }
     let Some(latest) = latest_version().await else {
-        return Ok(None);
+        return UpdateStatus::Silent;
     };
     if !is_newer(current_version(), &latest) {
-        return Ok(None);
+        return UpdateStatus::Silent;
     }
 
     #[cfg(feature = "binary-release")]
     {
-        let current = std::env::current_exe().context("could not locate the running executable")?;
-        install_from(&release_asset_url(&latest)?, &current).await?;
-        Ok(Some(latest))
+        // A fresh cache remembering a failed install of this same version
+        // means the download would fail the same way — surface the standing
+        // failure without re-spending the bandwidth. Retried when the cache
+        // expires or a newer release appears.
+        if let Some(cache) = read_cache()
+            && now_secs().saturating_sub(cache.checked_at) < CACHE_TTL_SECS
+            && let Some(failure) = cache.install_failed
+            && failure.version == latest
+        {
+            return UpdateStatus::InstallFailed {
+                version: latest,
+                reason: failure.reason,
+            };
+        }
+
+        let result = async {
+            let current =
+                std::env::current_exe().context("could not locate the running executable")?;
+            install_from(&release_asset_url(&latest)?, &current).await
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                // Clear a failure memo left by an older release's failed install.
+                if let Some(mut cache) = read_cache()
+                    && cache.install_failed.is_some()
+                {
+                    cache.install_failed = None;
+                    write_cache(&cache);
+                }
+                UpdateStatus::Installed(latest)
+            }
+            Err(error) => {
+                let reason = format!("{error:#}");
+                if let Some(mut cache) = read_cache() {
+                    cache.install_failed = Some(InstallFailure {
+                        version: latest.clone(),
+                        reason: reason.clone(),
+                    });
+                    write_cache(&cache);
+                }
+                UpdateStatus::InstallFailed {
+                    version: latest,
+                    reason,
+                }
+            }
+        }
     }
-    // Installed by cargo: replacing the binary in place would be undone by the
-    // next `cargo install`, and recompiling the crate underneath a running TUI
-    // is not something to do unasked. Report it instead.
     #[cfg(not(feature = "binary-release"))]
     {
-        Ok(Some(latest))
+        UpdateStatus::Available(latest)
     }
-}
-
-/// Whether an update installs itself or is merely announced, for the wording of
-/// the notification.
-pub const fn installs_in_place() -> bool {
-    cfg!(feature = "binary-release")
 }
 
 #[cfg(test)]
@@ -293,28 +437,82 @@ mod tests {
         assert_eq!(is_dev_build(), current_version() == "0.0.0");
     }
 
+    /// Serve the asset and its sibling `.sha256` from a throwaway local
+    /// server. `checksum` is the full text of the checksum file; `None` serves
+    /// a 404 for it, the shape of a release published without one.
+    fn serve_release(
+        payload: &'static [u8],
+        checksum: Option<String>,
+    ) -> (u16, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let handle = std::thread::spawn(move || {
+            // One connection for the asset, one for the checksum.
+            for _ in 0..2 {
+                let Ok((mut socket, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buf = [0u8; 1024];
+                let n = socket.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let wants_checksum = request
+                    .split_whitespace()
+                    .nth(1)
+                    .is_some_and(|path| path.ends_with(".sha256"));
+                let response = if wants_checksum {
+                    match &checksum {
+                        Some(text) => format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            text.len(),
+                            text
+                        )
+                        .into_bytes(),
+                        None => b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec(),
+                    }
+                } else {
+                    let mut head = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        payload.len()
+                    )
+                    .into_bytes();
+                    head.extend_from_slice(payload);
+                    head
+                };
+                socket.write_all(&response).expect("respond");
+            }
+        });
+        (port, handle)
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use sha2::Digest;
+        format!("{:x}", sha2::Sha256::digest(bytes))
+    }
+
+    /// The directory must hold exactly the target — no staging leftovers under
+    /// any name.
+    fn assert_no_leftovers(dir: &std::path::Path) {
+        let entries: Vec<_> = std::fs::read_dir(dir)
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert_eq!(
+            entries,
+            vec![std::ffi::OsString::from("forestui")],
+            "leftover staging files"
+        );
+    }
+
     /// The download-and-swap is the one step that can destroy a working install,
     /// so it is exercised for real: a local server, a temporary file standing in
     /// for the running binary, and assertions on the bytes, the permissions and
     /// the absence of leftovers.
     #[tokio::test]
     async fn install_from_replaces_the_target_atomically() {
-        use std::io::{Read, Write};
         let payload = b"#!/bin/sh\necho new version\n";
-
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-        let port = listener.local_addr().expect("addr").port();
-        let server = std::thread::spawn(move || {
-            let (mut socket, _) = listener.accept().expect("accept");
-            let mut buf = [0u8; 1024];
-            let _ = socket.read(&mut buf);
-            let head = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                payload.len()
-            );
-            socket.write_all(head.as_bytes()).expect("head");
-            socket.write_all(payload).expect("body");
-        });
+        let checksum = format!("{}  forestui_linux_x86_64\n", sha256_hex(payload));
+        let (port, server) = serve_release(payload, Some(checksum));
 
         let dir = tempfile::tempdir().expect("tempdir");
         let target = dir.path().join("forestui");
@@ -326,10 +524,7 @@ mod tests {
         server.join().expect("server");
 
         assert_eq!(std::fs::read(&target).expect("read back"), payload);
-        assert!(
-            !target.with_extension("tmp-update").exists(),
-            "the staging file was left behind"
-        );
+        assert_no_leftovers(dir.path());
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -339,6 +534,84 @@ mod tests {
                 .mode();
             assert_eq!(mode & 0o111, 0o111, "the replacement is not executable");
         }
+    }
+
+    /// A download that does not match its published checksum must leave the
+    /// running install byte-identical and no staging file behind.
+    #[tokio::test]
+    async fn a_corrupted_download_leaves_the_target_untouched() {
+        let payload = b"corrupted-in-transit";
+        let checksum = format!(
+            "{}  forestui_linux_x86_64\n",
+            sha256_hex(b"what was published")
+        );
+        let (port, server) = serve_release(payload, Some(checksum));
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("forestui");
+        std::fs::write(&target, b"old version").expect("seed the target");
+
+        let error = install_from(&format!("http://127.0.0.1:{port}/asset"), &target)
+            .await
+            .expect_err("a checksum mismatch must fail");
+        server.join().expect("server");
+
+        assert!(error.to_string().contains("checksum"), "got: {error:#}");
+        assert_eq!(std::fs::read(&target).expect("read back"), b"old version");
+        assert_no_leftovers(dir.path());
+    }
+
+    /// No checksum, no update: trusting whatever arrived over the wire is the
+    /// failure mode the verification exists to prevent.
+    #[tokio::test]
+    async fn a_missing_checksum_aborts_the_update() {
+        let payload = b"plausible payload";
+        let (port, server) = serve_release(payload, None);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("forestui");
+        std::fs::write(&target, b"old version").expect("seed the target");
+
+        assert!(
+            install_from(&format!("http://127.0.0.1:{port}/asset"), &target)
+                .await
+                .is_err()
+        );
+        server.join().expect("server");
+        assert_eq!(std::fs::read(&target).expect("read back"), b"old version");
+        assert_no_leftovers(dir.path());
+    }
+
+    /// Concurrent instances must stage privately — a shared staging path lets
+    /// one process rename another's half-written file into place.
+    #[test]
+    fn staging_is_per_process() {
+        let staged = staging_path(std::path::Path::new("/opt/bin/forestui"));
+        assert_eq!(staged.parent(), Some(std::path::Path::new("/opt/bin")));
+        let name = staged.file_name().unwrap().to_string_lossy().to_string();
+        assert_eq!(name, format!("forestui.tmp-update-{}", std::process::id()));
+    }
+
+    /// Every variant renders into the notification the app shows; constructing
+    /// them all here also keeps the cfg-gated arms from tripping dead-code.
+    #[test]
+    fn update_status_covers_every_outcome() {
+        let statuses = [
+            UpdateStatus::Silent,
+            UpdateStatus::Installed("2.0.0".into()),
+            UpdateStatus::Available("2.0.0".into()),
+            UpdateStatus::InstallFailed {
+                version: "2.0.0".into(),
+                reason: "permission denied".into(),
+            },
+        ];
+        assert_eq!(
+            statuses
+                .iter()
+                .filter(|s| **s == UpdateStatus::Silent)
+                .count(),
+            1
+        );
     }
 
     /// A failed download must leave the existing binary alone — a missed update
@@ -361,13 +634,13 @@ mod tests {
                 .is_err()
         );
         assert_eq!(std::fs::read(&target).expect("read back"), b"old version");
-        assert!(!target.with_extension("tmp-update").exists());
+        assert_no_leftovers(dir.path());
     }
 
     #[tokio::test]
     async fn a_dev_build_does_no_work() {
         if is_dev_build() {
-            assert!(update_if_stale().await.expect("no error").is_none());
+            assert_eq!(update_if_stale().await, UpdateStatus::Silent);
         }
     }
 }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -9,11 +9,17 @@
 //! subcommand, which is where this differs from `lineark` and `terminal-use`:
 //!
 //! - It never blocks the UI. The check runs on a background task after the
-//!   terminal is up, and the only thing the user sees is a notification once a
-//!   new version is already installed.
+//!   terminal is up. Success shows one notification; network failures stay
+//!   silent (offline is the common case, not the user's problem); only a
+//!   *persistent local* failure — an unwritable install dir — surfaces as an
+//!   error, and is remembered in the cache so the download is not re-spent on
+//!   every launch.
 //! - It only ever replaces a binary that came from a release. A `cargo install`
 //!   build defers to cargo, and a source build (version `0.0.0`) does nothing at
 //!   all, so `cargo run` in a checkout is never overwritten.
+//! - It never installs what it cannot verify: the downloaded bytes must match
+//!   the `.sha256` published beside the asset, so a release must ship its
+//!   checksums for the updater to accept it.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -94,7 +100,10 @@ fn write_cache(cache: &VersionCache) {
         let _ = std::fs::create_dir_all(parent);
     }
     if let Ok(json) = serde_json::to_string_pretty(cache) {
-        let _ = std::fs::write(&path, json);
+        // Atomic like the config files: the cache now carries the install
+        // failure memo and is shared by concurrent instances, so a torn write
+        // must not be able to silently drop it.
+        let _ = crate::util::write_atomically(&path, &json);
     }
 }
 
@@ -204,9 +213,35 @@ pub fn release_asset_url(version: &str) -> Result<String> {
 pub(crate) async fn install_from(url: &str, target: &std::path::Path) -> Result<()> {
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(90))
+        // Idle-based, not a total deadline: the asset is several MB, and a
+        // slow-but-moving link must not be killed mid-transfer. What the
+        // timeout exists for is a connection that stops answering.
+        .read_timeout(std::time::Duration::from_secs(30))
         .build()
         .context("could not build the HTTP client")?;
+
+    // The checksum is a hundred bytes and gates the multi-MB download; fetch
+    // it first so its absence or unreachability costs nothing.
+    let checksum_body = client
+        .get(format!("{url}.sha256"))
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .context("could not fetch the release checksum")?
+        .error_for_status()
+        .context("the release checksum request failed")?
+        .text()
+        .await
+        .context("could not read the release checksum")?;
+    // Coreutils format: `<64 hex>  <filename>`. Only the hash is trusted.
+    let expected = checksum_body
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(ChecksumError("the release checksum file is malformed".into()).into());
+    }
 
     let bytes = client
         .get(url)
@@ -220,76 +255,81 @@ pub(crate) async fn install_from(url: &str, target: &std::path::Path) -> Result<
         .await
         .context("could not read the downloaded release")?;
 
-    // Verify before anything touches disk.
-    let checksum_body = client
-        .get(format!("{url}.sha256"))
-        .header("User-Agent", USER_AGENT)
-        .send()
-        .await
-        .context("could not fetch the release checksum")?
-        .error_for_status()
-        .context("the release has no checksum")?
-        .text()
-        .await
-        .context("could not read the release checksum")?;
-    // Coreutils format: `<64 hex>  <filename>`. Only the hash is trusted.
-    let expected = checksum_body
-        .split_whitespace()
-        .next()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
-        anyhow::bail!("the release checksum file is malformed");
-    }
     use sha2::Digest;
     let actual = format!("{:x}", sha2::Sha256::digest(&bytes));
     if actual != expected {
-        anyhow::bail!("the downloaded release does not match its checksum");
+        return Err(ChecksumError(
+            "the downloaded release does not match its published checksum".into(),
+        )
+        .into());
     }
 
-    let staged = staging_path(target);
-    // All the fallible steps live in one helper so every failure path — write,
-    // chmod, rename — cleans the staged file up rather than leaving a stray
-    // binary beside the real one. Same contract as `util::write_atomically`.
-    let result = write_staged_then_rename(&staged, target, &bytes).await;
-    if result.is_err() {
-        let _ = tokio::fs::remove_file(&staged).await;
-    }
-    result
-}
-
-/// Sibling of `target` with a per-process suffix, so concurrent instances
-/// stage privately: the last rename wins whole-file, which is fine — both
-/// downloaded (and verified) the same asset.
-#[cfg(any(feature = "binary-release", test))]
-fn staging_path(target: &std::path::Path) -> PathBuf {
-    let mut name = target.file_name().unwrap_or_default().to_os_string();
-    name.push(format!(".tmp-update-{}", std::process::id()));
-    target.with_file_name(name)
-}
-
-#[cfg(any(feature = "binary-release", test))]
-async fn write_staged_then_rename(
-    staged: &std::path::Path,
-    target: &std::path::Path,
-    bytes: &[u8],
-) -> Result<()> {
-    tokio::fs::write(staged, bytes)
-        .await
-        .context("could not write the downloaded release")?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o755))
-            .await
-            .context("could not mark the downloaded release executable")?;
-    }
-
-    tokio::fs::rename(staged, target)
-        .await
-        .context("could not replace the running binary")?;
+    // The swap reuses the config files' atomic writer: sibling temp file with a
+    // per-pid name (concurrent instances stage privately), fsync before the
+    // rename and the directory after it (a power loss must not land the rename
+    // without the bytes), write-through for a symlinked install path, and the
+    // target's own mode carried over — with 0o755 as the floor that keeps the
+    // binary runnable.
+    let target = target.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        sweep_stale_staging(&target);
+        crate::util::write_bytes_atomically(&target, &bytes, Some(0o755))
+    })
+    .await
+    .context("the install task was cancelled")?
+    .context("could not replace the running binary")?;
     Ok(())
+}
+
+/// A download that could not be verified. Its own type so the caller can tell
+/// it from a local install failure: an unverifiable download is retried on the
+/// next launch, never memoized as persistent.
+#[cfg(any(feature = "binary-release", test))]
+#[derive(Debug)]
+pub(crate) struct ChecksumError(String);
+
+#[cfg(any(feature = "binary-release", test))]
+impl std::fmt::Display for ChecksumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(any(feature = "binary-release", test))]
+impl std::error::Error for ChecksumError {}
+
+/// Remove staging leftovers from crashed installs. A SIGKILL or power loss
+/// between write and rename orphans `<name>.tmp-<pid>` — a multi-MB, possibly
+/// executable file on `$PATH` that nothing else ever looks at again. Only
+/// files older than an hour go: a younger sibling may be a live concurrent
+/// instance mid-stage.
+#[cfg(any(feature = "binary-release", test))]
+fn sweep_stale_staging(target: &std::path::Path) {
+    let Some(parent) = target.parent() else {
+        return;
+    };
+    let Some(name) = target.file_name().map(|n| n.to_string_lossy().to_string()) else {
+        return;
+    };
+    let prefix = format!("{name}.tmp-");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .map(|modified| {
+                modified.elapsed().unwrap_or_default() > std::time::Duration::from_secs(3600)
+            })
+            .unwrap_or(false);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// What the startup update check concluded.
@@ -315,6 +355,28 @@ pub enum UpdateStatus {
     InstallFailed { version: String, reason: String },
 }
 
+impl UpdateStatus {
+    /// The toast this outcome earns, if any.
+    pub fn notification(&self) -> Option<(String, crate::event::Severity)> {
+        use crate::event::Severity;
+        match self {
+            UpdateStatus::Silent => None,
+            UpdateStatus::Installed(version) => Some((
+                format!("forestui v{version} installed — restart to use it"),
+                Severity::Information,
+            )),
+            UpdateStatus::Available(version) => Some((
+                format!("forestui v{version} is available — `cargo install forestui`"),
+                Severity::Information,
+            )),
+            UpdateStatus::InstallFailed { version, reason } => Some((
+                format!("forestui v{version} is available but could not be installed: {reason}"),
+                Severity::Error,
+            )),
+        }
+    }
+}
+
 /// Bring the installed binary up to date.
 pub async fn update_if_stale() -> UpdateStatus {
     if is_dev_build() {
@@ -329,59 +391,104 @@ pub async fn update_if_stale() -> UpdateStatus {
 
     #[cfg(feature = "binary-release")]
     {
-        // A fresh cache remembering a failed install of this same version
-        // means the download would fail the same way — surface the standing
-        // failure without re-spending the bandwidth. Retried when the cache
-        // expires or a newer release appears.
-        if let Some(cache) = read_cache()
-            && now_secs().saturating_sub(cache.checked_at) < CACHE_TTL_SECS
-            && let Some(failure) = cache.install_failed
-            && failure.version == latest
-        {
-            return UpdateStatus::InstallFailed {
-                version: latest,
-                reason: failure.reason,
-            };
-        }
-
-        let result = async {
-            let current =
-                std::env::current_exe().context("could not locate the running executable")?;
-            install_from(&release_asset_url(&latest)?, &current).await
-        }
-        .await;
-
-        match result {
-            Ok(()) => {
-                // Clear a failure memo left by an older release's failed install.
-                if let Some(mut cache) = read_cache()
-                    && cache.install_failed.is_some()
-                {
-                    cache.install_failed = None;
-                    write_cache(&cache);
-                }
-                UpdateStatus::Installed(latest)
-            }
-            Err(error) => {
-                let reason = format!("{error:#}");
-                if let Some(mut cache) = read_cache() {
-                    cache.install_failed = Some(InstallFailure {
-                        version: latest.clone(),
-                        reason: reason.clone(),
-                    });
-                    write_cache(&cache);
-                }
-                UpdateStatus::InstallFailed {
-                    version: latest,
-                    reason,
-                }
-            }
-        }
+        install_update(&latest).await
     }
     #[cfg(not(feature = "binary-release"))]
     {
         UpdateStatus::Available(latest)
     }
+}
+
+#[cfg(feature = "binary-release")]
+async fn install_update(latest: &str) -> UpdateStatus {
+    // One read, threaded through the guard and the memo writes: the cache file
+    // is read-modify-write state shared with concurrent instances, and every
+    // extra read widens the race.
+    let cache = read_cache();
+    let fresh = cache
+        .as_ref()
+        .is_some_and(|c| now_secs().saturating_sub(c.checked_at) < CACHE_TTL_SECS);
+    // A version the lookup could not refresh is the offline fallback.
+    // Downloading on that signal would fail — and nag — on every launch until
+    // the network returns; offline stays silent.
+    if !fresh {
+        return UpdateStatus::Silent;
+    }
+
+    // A remembered failed install of this same version would fail the same way
+    // — surface the standing failure without re-spending the bandwidth.
+    // Retried when the cache expires or a newer release appears.
+    if let Some(failure) = cache.as_ref().and_then(|c| c.install_failed.clone())
+        && failure.version == latest
+    {
+        return UpdateStatus::InstallFailed {
+            version: failure.version,
+            reason: failure.reason,
+        };
+    }
+
+    let result = async {
+        let current = std::env::current_exe().context("could not locate the running executable")?;
+        // On Linux `/proc/self/exe` reads "<path> (deleted)" once another
+        // instance's update has replaced the binary under this process. The
+        // new build is already in place; installing to that literal name would
+        // only strand a copy beside it.
+        if !current.exists() {
+            return Ok(false);
+        }
+        install_from(&release_asset_url(latest)?, &current)
+            .await
+            .map(|()| true)
+    }
+    .await;
+
+    match result {
+        Ok(false) => UpdateStatus::Silent,
+        Ok(true) => {
+            // Clear a memo left by an older release's failed install.
+            if let Some(mut cache) = cache
+                && cache.install_failed.is_some()
+            {
+                cache.install_failed = None;
+                write_cache(&cache);
+            }
+            UpdateStatus::Installed(latest.to_string())
+        }
+        Err(error) => {
+            // The network, a mid-transfer drop, a release published before its
+            // assets finished uploading, a download that failed verification:
+            // all transient. Retried silently on the next launch — being
+            // offline is not the user's problem.
+            if failure_is_transient(&error) {
+                return UpdateStatus::Silent;
+            }
+            // What remains is local and will repeat identically (an unwritable
+            // install dir): remember it and say so.
+            let reason = format!("{error:#}");
+            if let Some(mut cache) = cache {
+                cache.install_failed = Some(InstallFailure {
+                    version: latest.to_string(),
+                    reason: reason.clone(),
+                });
+                write_cache(&cache);
+            }
+            UpdateStatus::InstallFailed {
+                version: latest.to_string(),
+                reason,
+            }
+        }
+    }
+}
+
+/// Whether a failed install should be retried silently rather than remembered
+/// and surfaced. Network-level failures and unverifiable downloads are
+/// transient; local filesystem failures repeat identically until the user acts.
+#[cfg(any(feature = "binary-release", test))]
+fn failure_is_transient(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause.downcast_ref::<reqwest::Error>().is_some()
+            || cause.downcast_ref::<ChecksumError>().is_some()
+    })
 }
 
 #[cfg(test)]
@@ -439,17 +546,19 @@ mod tests {
 
     /// Serve the asset and its sibling `.sha256` from a throwaway local
     /// server. `checksum` is the full text of the checksum file; `None` serves
-    /// a 404 for it, the shape of a release published without one.
+    /// a 404 for it, the shape of a release published without one. `requests`
+    /// is how many connections the caller expects `install_from` to make — a
+    /// rejected checksum never fetches the asset at all.
     fn serve_release(
         payload: &'static [u8],
         checksum: Option<String>,
+        requests: usize,
     ) -> (u16, std::thread::JoinHandle<()>) {
         use std::io::{Read, Write};
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         let handle = std::thread::spawn(move || {
-            // One connection for the asset, one for the checksum.
-            for _ in 0..2 {
+            for _ in 0..requests {
                 let Ok((mut socket, _)) = listener.accept() else {
                     return;
                 };
@@ -512,7 +621,7 @@ mod tests {
     async fn install_from_replaces_the_target_atomically() {
         let payload = b"#!/bin/sh\necho new version\n";
         let checksum = format!("{}  forestui_linux_x86_64\n", sha256_hex(payload));
-        let (port, server) = serve_release(payload, Some(checksum));
+        let (port, server) = serve_release(payload, Some(checksum), 2);
 
         let dir = tempfile::tempdir().expect("tempdir");
         let target = dir.path().join("forestui");
@@ -545,7 +654,7 @@ mod tests {
             "{}  forestui_linux_x86_64\n",
             sha256_hex(b"what was published")
         );
-        let (port, server) = serve_release(payload, Some(checksum));
+        let (port, server) = serve_release(payload, Some(checksum), 2);
 
         let dir = tempfile::tempdir().expect("tempdir");
         let target = dir.path().join("forestui");
@@ -566,7 +675,8 @@ mod tests {
     #[tokio::test]
     async fn a_missing_checksum_aborts_the_update() {
         let payload = b"plausible payload";
-        let (port, server) = serve_release(payload, None);
+        // The checksum gates the download, so the asset is never requested.
+        let (port, server) = serve_release(payload, None, 1);
 
         let dir = tempfile::tempdir().expect("tempdir");
         let target = dir.path().join("forestui");
@@ -582,36 +692,94 @@ mod tests {
         assert_no_leftovers(dir.path());
     }
 
-    /// Concurrent instances must stage privately — a shared staging path lets
-    /// one process rename another's half-written file into place.
-    #[test]
-    fn staging_is_per_process() {
-        let staged = staging_path(std::path::Path::new("/opt/bin/forestui"));
-        assert_eq!(staged.parent(), Some(std::path::Path::new("/opt/bin")));
-        let name = staged.file_name().unwrap().to_string_lossy().to_string();
-        assert_eq!(name, format!("forestui.tmp-update-{}", std::process::id()));
+    /// A crashed install orphans its staged file — a multi-MB executable on
+    /// `$PATH`. The next install sweeps old leftovers, but must leave young
+    /// siblings alone: one may be a live concurrent instance mid-stage.
+    #[tokio::test]
+    async fn stale_staging_leftovers_are_swept() {
+        let payload = b"#!/bin/sh\necho new version\n";
+        let checksum = format!("{}  forestui_linux_x86_64\n", sha256_hex(payload));
+        let (port, server) = serve_release(payload, Some(checksum), 2);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("forestui");
+        std::fs::write(&target, b"old version").expect("seed the target");
+
+        let stale = dir.path().join("forestui.tmp-99999");
+        std::fs::write(&stale, b"crashed install").expect("seed stale leftover");
+        let two_hours_ago = std::time::SystemTime::now() - std::time::Duration::from_secs(2 * 3600);
+        std::fs::File::options()
+            .write(true)
+            .open(&stale)
+            .expect("open stale")
+            .set_times(std::fs::FileTimes::new().set_modified(two_hours_ago))
+            .expect("age the leftover");
+
+        let fresh = dir.path().join("forestui.tmp-88888");
+        std::fs::write(&fresh, b"concurrent instance").expect("seed fresh sibling");
+
+        install_from(&format!("http://127.0.0.1:{port}/asset"), &target)
+            .await
+            .expect("install");
+        server.join().expect("server");
+
+        assert!(!stale.exists(), "the stale leftover was not swept");
+        assert!(fresh.exists(), "a young sibling may be a live stage");
+        assert_eq!(std::fs::read(&target).expect("read back"), payload);
     }
 
-    /// Every variant renders into the notification the app shows; constructing
-    /// them all here also keeps the cfg-gated arms from tripping dead-code.
+    /// The notification is part of the module's contract with the app: every
+    /// outcome maps to exactly the toast the user should see.
     #[test]
-    fn update_status_covers_every_outcome() {
-        let statuses = [
-            UpdateStatus::Silent,
-            UpdateStatus::Installed("2.0.0".into()),
-            UpdateStatus::Available("2.0.0".into()),
-            UpdateStatus::InstallFailed {
-                version: "2.0.0".into(),
-                reason: "permission denied".into(),
-            },
-        ];
-        assert_eq!(
-            statuses
-                .iter()
-                .filter(|s| **s == UpdateStatus::Silent)
-                .count(),
-            1
+    fn every_outcome_maps_to_its_notification() {
+        use crate::event::Severity;
+
+        assert!(UpdateStatus::Silent.notification().is_none());
+
+        let (message, severity) = UpdateStatus::Installed("2.0.0".into())
+            .notification()
+            .expect("installed notifies");
+        assert!(
+            message.contains("v2.0.0") && message.contains("restart"),
+            "{message}"
         );
+        assert!(matches!(severity, Severity::Information));
+
+        let (message, severity) = UpdateStatus::Available("2.0.0".into())
+            .notification()
+            .expect("available notifies");
+        assert!(message.contains("cargo install"), "{message}");
+        assert!(matches!(severity, Severity::Information));
+
+        let (message, severity) = UpdateStatus::InstallFailed {
+            version: "2.0.0".into(),
+            reason: "permission denied".into(),
+        }
+        .notification()
+        .expect("failure notifies");
+        assert!(
+            message.contains("could not be installed") && message.contains("permission denied"),
+            "{message}"
+        );
+        assert!(matches!(severity, Severity::Error));
+    }
+
+    /// Network failures and unverifiable downloads retry silently; only local
+    /// failures — which repeat identically — are remembered and surfaced.
+    #[test]
+    fn only_local_failures_count_as_persistent() {
+        let checksum = anyhow::Error::new(ChecksumError("mismatch".into()));
+        assert!(failure_is_transient(&checksum));
+        assert!(failure_is_transient(&checksum.context("wrapped")));
+
+        let io = anyhow::Error::new(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "read-only file system",
+        ));
+        assert!(!failure_is_transient(&io));
+        assert!(!failure_is_transient(
+            &io.context("could not replace the running binary")
+        ));
     }
 
     /// A failed download must leave the existing binary alone — a missed update


### PR DESCRIPTION
One PR for the three self-update issues from the #34 review — they all touch the same `install_from`/`update_if_stale` path.

## #36 — checksum verification
- `install_from` fetches the sibling `.sha256` (coreutils format, first token) and verifies the downloaded bytes **before anything touches disk**.
- Missing, unfetchable, or malformed checksum → abort; the running install stays byte-identical.
- `sha2` added as a direct dependency (was only transitive via ratatui).

## #37 — per-process staging
- Staging path is now `<binary>.tmp-update-<pid>`, mirroring `util::write_atomically`, so concurrent instances stage privately; the last rename wins whole-file (both verified the same asset).
- All fallible steps (write, chmod, rename) live in one helper so **every** failure path cleans the staged file — the old code leaked it on write/chmod failures.

## #38 — timeouts + surfaced persistent failures
- Version lookup: 10s timeout, 5s connect. Asset+checksum download: 90s timeout, 10s connect.
- `update_if_stale` now returns an `UpdateStatus` enum instead of `Result<Option<String>>`; the app matches on it. Offline stays silent, but a post-lookup install failure surfaces once per launch: *"forestui vX is available but could not be installed: reason"*.
- The failure is memoized in the version cache (`install_failed`, serde-defaulted so old cache files load), so the multi-MB download is not re-spent every launch while it would fail identically; retried on cache expiry or a newer release. Failed *lookups* deliberately stay uncached — one cheap API call, and caching them would delay update detection by 24h after connectivity returns.

## Testing
- Local-server harness extended to serve the asset **and** its `.sha256` (or a 404): happy path, checksum mismatch (target byte-identical, no staging leftovers), missing checksum aborts, connection refused unchanged.
- `staging_is_per_process` pins the pid suffix; `make check` and `make check-shipped` both green (164 tests) — the updater is feature-gated, so the shipped config is the one that matters here.

Closes #36
Closes #37
Closes #38