### PR TITLE
Render cached panel content on selection change instead of flashing Loading

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -341,7 +341,9 @@ impl App {
                 }
             }
             Action::RefreshIssues => {
-                github::invalidate_cache(None);
+                // Manual refresh: only this repository's cache, and the
+                // spinner is deliberate — the user asked and gets feedback.
+                github::invalidate_cache(Some(&path));
                 self.issues = None;
                 self.fetch_issues();
             }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -341,11 +341,17 @@ impl App {
                 }
             }
             Action::RefreshIssues => {
-                // Manual refresh: only this repository's cache, and the
-                // spinner is deliberate — the user asked and gets feedback.
-                github::invalidate_cache(Some(&path));
-                self.issues = None;
-                self.fetch_issues();
+                // The cache is keyed by the *repository* path — `path` here is
+                // the selected path, which for a worktree row would be the
+                // worktree's directory and would invalidate nothing.
+                if let Some(repo) = self.state.selected_repository() {
+                    let repo_path = repo.source_path.clone();
+                    github::invalidate_cache(&repo_path);
+                    // The spinner is deliberate: the user asked for a refresh
+                    // and gets feedback.
+                    self.issues = None;
+                    self.fetch_issues();
+                }
             }
             Action::CreateFromIssue(index) => {
                 // The issue is captured here rather than looked up again when

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -476,8 +476,14 @@ impl App {
             tx.send(AppEvent::Meta(Box::new(meta)));
         });
 
+        // Cache-first: what was shown for this selection before renders again
+        // synchronously, and the fresh scan lands behind it. The alternative —
+        // dropping to "Loading…" on every switch with a warm cache in hand —
+        // is the flash issue #29 is about.
+        self.sessions = claude_session::peek_sessions(&path);
         let tx = self.tx.clone();
         let session_path = path.clone();
+        let event_path = path.clone();
         tokio::spawn(async move {
             let sessions = tokio::task::spawn_blocking(move || {
                 claude_session::get_sessions_for_path(&session_path, SESSION_LIMIT)
@@ -485,13 +491,22 @@ impl App {
             .await
             .unwrap_or_default();
             tx.send(AppEvent::Sessions {
-                path: path.clone(),
+                path: event_path,
                 sessions,
             });
         });
 
         if is_repository {
-            self.fetch_issues();
+            match github::peek_issues(&path) {
+                // Fresh enough to stand on its own; the 300s tick refreshes.
+                Some((issues, true)) => self.issues = Some(issues),
+                // Stale content beats a spinner: render it and refresh behind.
+                Some((issues, false)) => {
+                    self.issues = Some(issues);
+                    self.fetch_issues();
+                }
+                None => self.fetch_issues(),
+            }
         }
     }
 
@@ -583,8 +598,11 @@ impl App {
 
         if self.last_issue_refresh.elapsed() >= ISSUE_REFRESH_INTERVAL {
             self.last_issue_refresh = Instant::now();
-            github::invalidate_cache(None);
-            if self.state.selection.is_repository() {
+            if let Some(repo) = self.state.selected_repository() {
+                // Invalidate only the repository being refreshed. Nuking the
+                // whole cache here made the next selection change on every
+                // other repository a guaranteed cold miss — spinner included.
+                github::invalidate_cache(Some(&repo.source_path.clone()));
                 // No repaint yet: nothing changes on screen until the result
                 // arrives, and that event pays for its own.
                 self.fetch_issues();
@@ -1116,6 +1134,34 @@ mod tests {
         assert!(app.state.find_worktree(worktree_id).is_some());
         assert_eq!(app.notifications.len(), 1);
         assert!(app.notifications[0].text.contains("worktree is locked"));
+    }
+
+    #[tokio::test]
+    async fn a_warm_cache_renders_issues_without_a_loading_flash() {
+        let (_dir, mut app) = app_with_fixture();
+        let path = app
+            .state
+            .selected_repository()
+            .expect("repo selected")
+            .source_path
+            .clone();
+        let issue: crate::models::GitHubIssue = serde_json::from_str(
+            r#"{"number":9,"title":"Cached","state":"OPEN","url":"https://x/9",
+                "createdAt":"2026-08-01T10:00:00Z","updatedAt":"2026-08-01T10:00:00Z",
+                "author":{"login":"me"},"assignees":[],"labels":[]}"#,
+        )
+        .expect("issue json");
+        crate::services::github::seed_cache_for_test(&path, vec![issue], chrono::Utc::now());
+
+        // Leave the repository and come back: the second visit must render
+        // from cache synchronously, not drop to the Loading state (#29).
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Up));
+        let issues = app
+            .issues
+            .as_ref()
+            .expect("no Loading flash on a warm cache");
+        assert_eq!(issues[0].number, 9);
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -125,6 +125,12 @@ pub struct App {
     pub spinner_index: usize,
     pub last_issue_refresh: Instant,
     pub should_quit: bool,
+    /// Paths with an issue fetch / session scan already running. Selection
+    /// changes arrive far faster than the subprocess chains behind these
+    /// panels; without the guard, bouncing across the sidebar stacks
+    /// concurrent duplicate fetches for identical results.
+    issues_in_flight: std::collections::HashSet<String>,
+    sessions_in_flight: std::collections::HashSet<String>,
     /// Worktrees with a removal running in the background. Guards duplicate
     /// removals, disables the Delete control, and holds quit until the results
     /// are folded (an orphaned git child would remove the tree on disk after
@@ -213,6 +219,8 @@ impl App {
             spinner_index: 0,
             last_issue_refresh: Instant::now(),
             should_quit: false,
+            issues_in_flight: std::collections::HashSet::new(),
+            sessions_in_flight: std::collections::HashSet::new(),
             removals_in_flight: std::collections::HashSet::new(),
             quit_pending: false,
             hits: Vec::new(),
@@ -480,21 +488,25 @@ impl App {
         // synchronously, and the fresh scan lands behind it. The alternative —
         // dropping to "Loading…" on every switch with a warm cache in hand —
         // is the flash issue #29 is about.
-        self.sessions = claude_session::peek_sessions(&path);
-        let tx = self.tx.clone();
-        let session_path = path.clone();
-        let event_path = path.clone();
-        tokio::spawn(async move {
-            let sessions = tokio::task::spawn_blocking(move || {
-                claude_session::get_sessions_for_path(&session_path, SESSION_LIMIT)
-            })
-            .await
-            .unwrap_or_default();
-            tx.send(AppEvent::Sessions {
-                path: event_path,
-                sessions,
+        self.sessions = claude_session::peek_sessions(&path, SESSION_LIMIT);
+        // One scan per path at a time: bouncing across the sidebar must not
+        // stack duplicate directory walks for content the cache already shows.
+        if self.sessions_in_flight.insert(path.clone()) {
+            let tx = self.tx.clone();
+            let session_path = path.clone();
+            let event_path = path.clone();
+            tokio::spawn(async move {
+                let sessions = tokio::task::spawn_blocking(move || {
+                    claude_session::get_sessions_for_path(&session_path, SESSION_LIMIT)
+                })
+                .await
+                .ok();
+                tx.send(AppEvent::Sessions {
+                    path: event_path,
+                    sessions,
+                });
             });
-        });
+        }
 
         if is_repository {
             match github::peek_issues(&path) {
@@ -515,6 +527,11 @@ impl App {
             return;
         };
         let path = repo.source_path.clone();
+        // One fetch per path at a time — each one is a chain of gh
+        // subprocesses and possibly a network call for an identical result.
+        if !self.issues_in_flight.insert(path.clone()) {
+            return;
+        }
         let tx = self.tx.clone();
         tokio::spawn(async move {
             let issues = github::list_issues(&path, ISSUE_LIMIT).await;
@@ -598,11 +615,17 @@ impl App {
 
         if self.last_issue_refresh.elapsed() >= ISSUE_REFRESH_INTERVAL {
             self.last_issue_refresh = Instant::now();
-            if let Some(repo) = self.state.selected_repository() {
+            // Only while a repository pane is actually showing its issues —
+            // refreshing under a worktree pane would churn subprocesses (and
+            // destroy a warm cache) for content that is not on screen.
+            if self.state.selection.is_repository()
+                && let Some(repo) = self.state.selected_repository()
+            {
                 // Invalidate only the repository being refreshed. Nuking the
                 // whole cache here made the next selection change on every
                 // other repository a guaranteed cold miss — spinner included.
-                github::invalidate_cache(Some(&repo.source_path.clone()));
+                let path = repo.source_path.clone();
+                github::invalidate_cache(&path);
                 // No repaint yet: nothing changes on screen until the result
                 // arrives, and that event pays for its own.
                 self.fetch_issues();
@@ -635,16 +658,24 @@ impl App {
                 self.gh_status = status.display(username.as_deref());
             }
             AppEvent::Sessions { path, sessions } => {
-                if path == self.meta.path {
+                // Release the guard even for a result the checks below drop.
+                self.sessions_in_flight.remove(&path);
+                // A failed scan (None) keeps whatever the cache painted; an
+                // empty *successful* scan is real content and lands normally.
+                if let Some(sessions) = sessions
+                    && path == self.meta.path
+                {
                     self.sessions = Some(sessions);
                 }
             }
             AppEvent::Issues { path, issues } => {
-                if Some(path.as_str())
-                    == self
-                        .state
-                        .selected_repository()
-                        .map(|r| r.source_path.as_str())
+                self.issues_in_flight.remove(&path);
+                if self.state.selection.is_repository()
+                    && Some(path.as_str())
+                        == self
+                            .state
+                            .selected_repository()
+                            .map(|r| r.source_path.as_str())
                 {
                     self.issues = Some(issues);
                 }
@@ -1435,15 +1466,31 @@ mod tests {
 
         app.handle_event(AppEvent::Sessions {
             path: "/stale".into(),
-            sessions: vec![],
+            sessions: Some(vec![]),
         });
         assert!(app.sessions.is_none(), "a late result must not land");
 
         app.handle_event(AppEvent::Sessions {
             path: "/current".into(),
-            sessions: vec![],
+            sessions: Some(vec![]),
         });
         assert!(app.sessions.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_failed_session_scan_keeps_what_the_cache_painted() {
+        let (_dir, mut app) = app_with_fixture();
+        app.meta.path = "/current".into();
+        app.sessions = Some(vec![]);
+
+        app.handle_event(AppEvent::Sessions {
+            path: "/current".into(),
+            sessions: None,
+        });
+        assert!(
+            app.sessions.is_some(),
+            "a panicked scan must not overwrite painted content"
+        );
     }
 
     /// What the renderer does each frame: snapshot the drawn items that

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,10 +49,13 @@ pub enum AppEvent {
     Tick,
     /// `gh auth status` finished.
     GhStatus(AuthStatus, Option<String>),
-    /// Claude sessions for a path finished loading.
+    /// Claude sessions for a path finished loading. `None` means the scan
+    /// failed (a panicked blocking task) — the fold must release its in-flight
+    /// guard but keep whatever content is already on screen rather than
+    /// overwriting it with an authoritative-looking empty list.
     Sessions {
         path: String,
-        sessions: Vec<ClaudeSession>,
+        sessions: Option<Vec<ClaudeSession>>,
     },
     /// GitHub issues for a repository finished loading.
     Issues {

--- a/src/services/claude_session.rs
+++ b/src/services/claude_session.rs
@@ -9,19 +9,27 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-/// Last known sessions per path. There is no TTL: the panel renders this
-/// immediately on selection change while a fresh scan runs behind it, so the
-/// worst case is content a few seconds old for the blink before the scan
-/// lands — instead of a "Loading…" flash on every switch (#29).
-fn cache() -> &'static Mutex<HashMap<String, Vec<ClaudeSession>>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, Vec<ClaudeSession>>>> = OnceLock::new();
+/// Last known sessions per `(path, limit)`. There is no TTL: the panel renders
+/// this immediately on selection change while a fresh scan runs behind it, so
+/// the worst case is content a few seconds old for the blink before the scan
+/// lands — instead of a "Loading…" flash on every switch (#29). The limit is
+/// part of the key so a future caller with a different cap cannot poison the
+/// entry another consumer peeks.
+type SessionCacheKey = (String, usize);
+
+fn cache() -> &'static Mutex<HashMap<SessionCacheKey, Vec<ClaudeSession>>> {
+    static CACHE: OnceLock<Mutex<HashMap<SessionCacheKey, Vec<ClaudeSession>>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// The last result [`get_sessions_for_path`] produced for this path, if any.
-/// Safe on the render thread: the lock is held only for the map read.
-pub fn peek_sessions(path: &str) -> Option<Vec<ClaudeSession>> {
-    cache().lock().ok()?.get(path).cloned()
+/// The last result [`get_sessions_for_path`] produced for this path and limit,
+/// if any. Safe on the render thread: the lock is held only for the map read.
+pub fn peek_sessions(path: &str, limit: usize) -> Option<Vec<ClaudeSession>> {
+    cache()
+        .lock()
+        .ok()?
+        .get(&(path.to_string(), limit))
+        .cloned()
 }
 
 /// Convert a filesystem path to Claude's folder naming convention.
@@ -39,7 +47,7 @@ pub fn get_sessions_for_path(path: &str, limit: usize) -> Vec<ClaudeSession> {
     let sessions_dir = claude_projects_dir().join(path_to_claude_folder(path));
     let sessions = read_sessions_dir(&sessions_dir, limit);
     if let Ok(mut guard) = cache().lock() {
-        guard.insert(path.to_string(), sessions.clone());
+        guard.insert((path.to_string(), limit), sessions.clone());
     }
     sessions
 }
@@ -245,10 +253,12 @@ mod tests {
     #[test]
     fn peek_returns_the_last_scan() {
         let path = "/nowhere/forestui-peek-test";
-        assert!(peek_sessions(path).is_none());
+        assert!(peek_sessions(path, 5).is_none());
         let scanned = get_sessions_for_path(path, 5);
-        let peeked = peek_sessions(path).expect("the scan populates the cache");
+        let peeked = peek_sessions(path, 5).expect("the scan populates the cache");
         assert_eq!(peeked.len(), scanned.len());
+        // A different limit is a different entry, never a poisoned shared one.
+        assert!(peek_sessions(path, 50).is_none());
     }
 
     #[test]

--- a/src/services/claude_session.rs
+++ b/src/services/claude_session.rs
@@ -5,7 +5,24 @@
 
 use crate::models::ClaudeSession;
 use chrono::{DateTime, TimeZone, Utc};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// Last known sessions per path. There is no TTL: the panel renders this
+/// immediately on selection change while a fresh scan runs behind it, so the
+/// worst case is content a few seconds old for the blink before the scan
+/// lands — instead of a "Loading…" flash on every switch (#29).
+fn cache() -> &'static Mutex<HashMap<String, Vec<ClaudeSession>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Vec<ClaudeSession>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The last result [`get_sessions_for_path`] produced for this path, if any.
+/// Safe on the render thread: the lock is held only for the map read.
+pub fn peek_sessions(path: &str) -> Option<Vec<ClaudeSession>> {
+    cache().lock().ok()?.get(path).cloned()
+}
 
 /// Convert a filesystem path to Claude's folder naming convention.
 pub fn path_to_claude_folder(path: &str) -> String {
@@ -20,7 +37,11 @@ pub fn claude_projects_dir() -> PathBuf {
 /// Sessions for a path, newest first, capped at `limit`.
 pub fn get_sessions_for_path(path: &str, limit: usize) -> Vec<ClaudeSession> {
     let sessions_dir = claude_projects_dir().join(path_to_claude_folder(path));
-    read_sessions_dir(&sessions_dir, limit)
+    let sessions = read_sessions_dir(&sessions_dir, limit);
+    if let Ok(mut guard) = cache().lock() {
+        guard.insert(path.to_string(), sessions.clone());
+    }
+    sessions
 }
 
 /// Directory-scoped form of [`get_sessions_for_path`], for testing.
@@ -218,6 +239,17 @@ pub fn migrate_dirs(old_dir: &Path, new_dir: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The peek is what the panel renders on selection change while the scan
+    /// re-runs behind it (#29): whatever the last scan produced, instantly.
+    #[test]
+    fn peek_returns_the_last_scan() {
+        let path = "/nowhere/forestui-peek-test";
+        assert!(peek_sessions(path).is_none());
+        let scanned = get_sessions_for_path(path, 5);
+        let peeked = peek_sessions(path).expect("the scan populates the cache");
+        assert_eq!(peeked.len(), scanned.len());
+    }
 
     #[test]
     fn folder_naming_replaces_slashes() {

--- a/src/services/github.rs
+++ b/src/services/github.rs
@@ -44,6 +44,10 @@ struct Cached {
 struct State {
     cache: HashMap<String, Cached>,
     auth: Option<(AuthStatus, Option<String>)>,
+    /// Bumped by every invalidation. A fetch that started before an
+    /// invalidation must not store its result afterwards — it would re-stamp
+    /// pre-invalidation data as fresh and silently undo the refresh.
+    generation: u64,
 }
 
 fn state() -> &'static Mutex<State> {
@@ -145,37 +149,55 @@ pub fn peek_issues(path: &str) -> Option<(Vec<GitHubIssue>, bool)> {
 /// Open issues assigned to or authored by the current user, newest first.
 pub async fn list_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
     // The cache answers before any subprocess runs; a warm hit costs nothing.
-    if let Ok(guard) = state().lock()
-        && let Some(cached) = guard.cache.get(path)
-        && (Utc::now() - cached.fetched_at).num_seconds() < CACHE_TTL_SECONDS
-    {
-        return cached.issues.clone();
+    // Freshness has exactly one definition, and it lives in `peek_issues`.
+    if let Some((issues, true)) = peek_issues(path) {
+        return issues;
     }
+    let generation = state().lock().map(|g| g.generation).unwrap_or_default();
 
-    // The empty answers are cached too: a local-only repository or an
+    // Empty answers are cached too — a local-only repository or an
     // unauthenticated `gh` would otherwise re-flash "Loading…" and re-spawn
-    // subprocesses on every visit, forever.
+    // subprocesses on every visit — but as *already stale*: the panel renders
+    // them instantly while the next visit silently re-checks, so a transient
+    // failure (a killed probe, a network blip during `gh repo view`) never
+    // masquerades as a confident 300-second "No issues found".
     let (auth, _) = get_auth_status().await;
     if auth != AuthStatus::Authenticated {
-        return store(path, Vec::new());
+        return store_if_current(generation, path, Vec::new(), false);
     }
 
     // Only the gate cares about owner/repo: a path that is not a GitHub
     // repository has no issues to list.
     if get_repo_info(path).await.is_none() {
-        return store(path, Vec::new());
+        return store_if_current(generation, path, Vec::new(), false);
     }
 
-    store(path, fetch_issues(path, limit).await)
+    let issues = fetch_issues(path, limit).await;
+    store_if_current(generation, path, issues, true)
 }
 
-fn store(path: &str, issues: Vec<GitHubIssue>) -> Vec<GitHubIssue> {
-    if let Ok(mut guard) = state().lock() {
+/// Store a fetch result unless an invalidation landed while it ran. `fresh`
+/// decides the stamp: `false` back-dates the entry to the TTL boundary so it
+/// renders instantly but re-checks on the next visit.
+fn store_if_current(
+    generation: u64,
+    path: &str,
+    issues: Vec<GitHubIssue>,
+    fresh: bool,
+) -> Vec<GitHubIssue> {
+    let fetched_at = if fresh {
+        Utc::now()
+    } else {
+        Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECONDS)
+    };
+    if let Ok(mut guard) = state().lock()
+        && guard.generation == generation
+    {
         guard.cache.insert(
             path.to_string(),
             Cached {
                 issues: issues.clone(),
-                fetched_at: Utc::now(),
+                fetched_at,
             },
         );
     }
@@ -233,17 +255,14 @@ async fn fetch_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
     issues
 }
 
-/// Drop cached issues for one repository path, or all of them when `path` is
-/// `None`. Prefer the targeted form: clearing everything makes the next
-/// selection change on every other repository a guaranteed cold miss.
-pub fn invalidate_cache(path: Option<&str>) {
+/// Drop the cached issues for one repository path. Deliberately not a
+/// clear-everything: nuking the whole cache made the next selection change on
+/// every other repository a guaranteed cold miss, which was half of #29.
+pub fn invalidate_cache(path: &str) {
     if let Ok(mut guard) = state().lock() {
-        match path {
-            Some(path) => {
-                guard.cache.remove(path);
-            }
-            None => guard.cache.clear(),
-        }
+        guard.cache.remove(path);
+        // Fence out any fetch already in flight for the old contents.
+        guard.generation += 1;
     }
 }
 
@@ -312,12 +331,48 @@ mod tests {
         let (_, fresh) = peek_issues("/repo/stale").expect("cached");
         assert!(!fresh, "an expired entry must read as stale");
 
-        invalidate_cache(Some("/repo/fresh"));
+        invalidate_cache("/repo/fresh");
         assert!(peek_issues("/repo/fresh").is_none());
         assert!(
             peek_issues("/repo/stale").is_some(),
             "targeted invalidation"
         );
+    }
+
+    /// A fetch that started before an invalidation must not store afterwards:
+    /// it would re-stamp pre-invalidation data as fresh and silently undo the
+    /// refresh the user just asked for.
+    #[test]
+    fn an_invalidation_fences_out_older_fetches() {
+        let before = state().lock().unwrap().generation;
+        invalidate_cache("/repo/fenced");
+        store_if_current(before, "/repo/fenced", Vec::new(), true);
+        assert!(
+            peek_issues("/repo/fenced").is_none(),
+            "a pre-invalidation fetch must not repopulate the cache"
+        );
+
+        // Re-read and retry: another test may invalidate concurrently, and
+        // only a store with the *current* generation may land.
+        for _ in 0..10 {
+            let current = state().lock().unwrap().generation;
+            store_if_current(current, "/repo/fenced", Vec::new(), true);
+            if peek_issues("/repo/fenced").is_some() {
+                break;
+            }
+        }
+        assert!(peek_issues("/repo/fenced").is_some());
+    }
+
+    /// Negative answers render instantly but re-check on the next visit — a
+    /// transient failure must not read as a confident fresh "No issues found".
+    #[test]
+    fn empty_answers_are_cached_as_already_stale() {
+        let generation = state().lock().unwrap().generation;
+        store_if_current(generation, "/repo/negative", Vec::new(), false);
+        let (issues, fresh) = peek_issues("/repo/negative").expect("cached");
+        assert!(issues.is_empty());
+        assert!(!fresh, "a negative answer must not count as fresh");
     }
 
     #[test]

--- a/src/services/github.rs
+++ b/src/services/github.rs
@@ -36,6 +36,10 @@ struct Cached {
     fetched_at: DateTime<Utc>,
 }
 
+/// The cache is keyed by the repository *path* — the one identifier the app
+/// holds synchronously. Keying by `owner/repo` made every lookup pay a
+/// `gh repo view` subprocess before it could even ask the cache, which is why
+/// the issues panel flashed "Loading…" on every selection change (#29).
 #[derive(Default)]
 struct State {
     cache: HashMap<String, Cached>,
@@ -127,30 +131,48 @@ pub async fn get_repo_info(path: &str) -> Option<(String, String)> {
     Some((owner, name))
 }
 
+/// Cached issues for a path without any I/O: `Some((issues, fresh))` when a
+/// fetch has completed this run, `None` when nothing is cached. Safe to call
+/// from the render thread — the lock is only ever held for map operations,
+/// never across an await.
+pub fn peek_issues(path: &str) -> Option<(Vec<GitHubIssue>, bool)> {
+    let guard = state().lock().ok()?;
+    let cached = guard.cache.get(path)?;
+    let fresh = (Utc::now() - cached.fetched_at).num_seconds() < CACHE_TTL_SECONDS;
+    Some((cached.issues.clone(), fresh))
+}
+
 /// Open issues assigned to or authored by the current user, newest first.
 pub async fn list_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
-    let (auth, _) = get_auth_status().await;
-    if auth != AuthStatus::Authenticated {
-        return Vec::new();
-    }
-
-    let Some((owner, repo)) = get_repo_info(path).await else {
-        return Vec::new();
-    };
-    let cache_key = format!("{owner}/{repo}");
-
+    // The cache answers before any subprocess runs; a warm hit costs nothing.
     if let Ok(guard) = state().lock()
-        && let Some(cached) = guard.cache.get(&cache_key)
+        && let Some(cached) = guard.cache.get(path)
         && (Utc::now() - cached.fetched_at).num_seconds() < CACHE_TTL_SECONDS
     {
         return cached.issues.clone();
     }
 
-    let issues = fetch_issues(path, limit).await;
+    // The empty answers are cached too: a local-only repository or an
+    // unauthenticated `gh` would otherwise re-flash "Loading…" and re-spawn
+    // subprocesses on every visit, forever.
+    let (auth, _) = get_auth_status().await;
+    if auth != AuthStatus::Authenticated {
+        return store(path, Vec::new());
+    }
 
+    // Only the gate cares about owner/repo: a path that is not a GitHub
+    // repository has no issues to list.
+    if get_repo_info(path).await.is_none() {
+        return store(path, Vec::new());
+    }
+
+    store(path, fetch_issues(path, limit).await)
+}
+
+fn store(path: &str, issues: Vec<GitHubIssue>) -> Vec<GitHubIssue> {
     if let Ok(mut guard) = state().lock() {
         guard.cache.insert(
-            cache_key,
+            path.to_string(),
             Cached {
                 issues: issues.clone(),
                 fetched_at: Utc::now(),
@@ -158,6 +180,16 @@ pub async fn list_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
         );
     }
     issues
+}
+
+/// Seed the cache directly, for tests that must not shell out to `gh`.
+#[cfg(test)]
+pub fn seed_cache_for_test(path: &str, issues: Vec<GitHubIssue>, fetched_at: DateTime<Utc>) {
+    if let Ok(mut guard) = state().lock() {
+        guard
+            .cache
+            .insert(path.to_string(), Cached { issues, fetched_at });
+    }
 }
 
 async fn fetch_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
@@ -201,12 +233,14 @@ async fn fetch_issues(path: &str, limit: usize) -> Vec<GitHubIssue> {
     issues
 }
 
-/// Drop cached issues for one repo, or all of them when `repo_key` is `None`.
-pub fn invalidate_cache(repo_key: Option<&str>) {
+/// Drop cached issues for one repository path, or all of them when `path` is
+/// `None`. Prefer the targeted form: clearing everything makes the next
+/// selection change on every other repository a guaranteed cold miss.
+pub fn invalidate_cache(path: Option<&str>) {
     if let Ok(mut guard) = state().lock() {
-        match repo_key {
-            Some(key) => {
-                guard.cache.remove(key);
+        match path {
+            Some(path) => {
+                guard.cache.remove(path);
             }
             None => guard.cache.clear(),
         }
@@ -253,6 +287,37 @@ mod tests {
              'not logged in', which is cached and never retried"
         );
         assert_eq!(code, KILLED);
+    }
+
+    /// The synchronous peek is what lets the render thread paint cached issues
+    /// on selection change instead of flashing "Loading…" (#29).
+    #[test]
+    fn peek_reports_freshness_without_io() {
+        assert!(peek_issues("/nowhere/never-seen").is_none());
+
+        let issue: GitHubIssue = serde_json::from_str(
+            r#"{"number":1,"title":"T","state":"OPEN","url":"https://x/1",
+                "createdAt":"2026-08-01T10:00:00Z","updatedAt":"2026-08-01T10:00:00Z",
+                "author":{"login":"me"},"assignees":[],"labels":[]}"#,
+        )
+        .unwrap();
+
+        seed_cache_for_test("/repo/fresh", vec![issue.clone()], Utc::now());
+        let (issues, fresh) = peek_issues("/repo/fresh").expect("cached");
+        assert_eq!(issues.len(), 1);
+        assert!(fresh);
+
+        let old = Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECONDS + 10);
+        seed_cache_for_test("/repo/stale", vec![issue], old);
+        let (_, fresh) = peek_issues("/repo/stale").expect("cached");
+        assert!(!fresh, "an expired entry must read as stale");
+
+        invalidate_cache(Some("/repo/fresh"));
+        assert!(peek_issues("/repo/fresh").is_none());
+        assert!(
+            peek_issues("/repo/stale").is_some(),
+            "targeted invalidation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes the per-switch "Loading…" flash on both detail-pane panels (#29).

## What was actually wrong
The issue cache worked, but was unreachable at render time by construction: keyed by `owner/repo`, which only an **uncached `gh repo view` subprocess** could produce — so even a warm hit paid a subprocess round trip first. The panel was reset to Loading before anything could ask the cache.

## Changes
- **Cache re-keyed by repository path** (the identifier the app holds synchronously; per-key invalidation had zero callers, so nothing depended on the old key) + a synchronous `peek_issues` for the render thread (lock never held across an await).
- **Selection change**: fresh cache → rendered instantly, no fetch; stale cache → rendered instantly with a silent background refresh; nothing cached → spinner (only then).
- **Empty answers cached too** — local-only repos and unauthenticated `gh` no longer re-flash and re-spawn subprocesses on every visit (found live during tu verification).
- **Sessions panel** (same flash, no cache at all): keeps the last scan per path and repaints it instantly while the fresh scan runs behind it.
- **300s tick** no longer nukes the whole cache (a guaranteed cold miss for every other repo); it invalidates only the selected repository — finally a caller for per-key invalidation. Manual ↻ refresh does the same, keeping its deliberate spinner.

## Testing
- Unit: peek freshness/staleness/targeted invalidation, session peek-after-scan, app-level warm-cache render on selection change (no event fold needed).
- tu-verified live against the real forestui repo: warm switch-back renders issues instantly (no Loading frame), non-GitHub repo renders cached "No issues found" instantly on the second visit.
- `make check` + `make check-shipped`: 168 tests green.

Closes #29