### PR TITLE
Document why the crates.io publish runs with --allow-dirty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
           sed -i "/^name = \"forestui\"$/{n;s/^version = \"0.0.0\"/version = \"${VERSION}\"/;}" Cargo.lock
           grep -A1 '^name = "forestui"$' Cargo.lock
 
+      # --allow-dirty is load-bearing, not leftover: the step above seds the
+      # tag's version into Cargo.toml and Cargo.lock without committing, so
+      # the tree is dirty by design at publish time. Removing the flag would
+      # require committing an ephemeral version-stamp commit instead.
       - name: Publish
         run: cargo publish --no-verify --allow-dirty
         env:


### PR DESCRIPTION
The last open checkbox of #31: `cargo publish --allow-dirty` was carried over from lineark rather than deliberately decided. Grooming concluded it is **load-bearing**: the workflow seds the tag version into `Cargo.toml`/`Cargo.lock` without committing, so the tree is dirty by design at publish time. This adds the why-comment beside the publish step so the flag reads as a decision, not leftovers.

Closes #31