### PR TITLE
Activate the saved theme on launch, not the legacy field

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -873,7 +873,7 @@ pub(crate) mod test_support {
 
     /// An app backed by a throwaway forest directory, with one repository that
     /// has two active worktrees and one archived worktree.
-    pub fn app_with_fixture() -> (tempfile::TempDir, App) {
+    fn fixture(settings: Settings) -> (tempfile::TempDir, App) {
         let dir = tempfile::tempdir().expect("tempdir");
         let mut state = AppState::load_from(dir.path().join(".forestui-config.json"));
 
@@ -913,9 +913,22 @@ pub(crate) mod test_support {
             worktree_id: None,
         };
 
-        let (tx, _rx) = crate::event::start();
-        let app = App::with_state(tx, state, Settings::default());
+        // A bare channel: `event::start` would add a detached stdin-polling
+        // thread per test. Dropping the receiver is fine — sends are
+        // best-effort and no test reads events back.
+        let (tx, _rx) = crate::event::test_channel();
+        let app = App::with_state(tx, state, settings);
         (dir, app)
+    }
+
+    /// [`app_with_fixture`] with explicit settings, for tests that need a
+    /// non-default configuration (a saved theme, a branch prefix).
+    pub fn app_with_settings(settings: Settings) -> (tempfile::TempDir, App) {
+        fixture(settings)
+    }
+
+    pub fn app_with_fixture() -> (tempfile::TempDir, App) {
+        fixture(Settings::default())
     }
 
     pub fn key(code: ratatui::crossterm::event::KeyCode) -> ratatui::crossterm::event::KeyEvent {
@@ -1181,21 +1194,16 @@ mod tests {
     #[tokio::test]
     async fn startup_activates_the_saved_theme() {
         let _guard = crate::theme::test_lock();
-        let dir = tempfile::tempdir().expect("tempdir");
-        let state = AppState::load_from(dir.path().join(".forestui-config.json"));
-        let (tx, _rx) = crate::event::start();
-        let settings = Settings {
+        let (_dir, _app) = test_support::app_with_settings(Settings {
             theme_name: "nord".into(),
             ..Settings::default()
-        };
-
-        let _app = App::with_state(tx, state, settings);
+        });
         assert_eq!(
             crate::theme::active().slug,
             "nord",
             "the saved theme must be active before the first frame"
         );
-        crate::theme::set_active("forest-dark");
+        // The guard restores the pre-test theme on drop.
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -202,7 +202,10 @@ impl App {
     pub fn with_state(tx: EventTx, state: AppState, settings: Settings) -> Self {
         // The renderers read the active theme from the global; activate the
         // saved one before the first frame so launch never flashes the default.
-        crate::theme::set_active(&settings.theme);
+        // `theme_name` carries the chosen slug — `theme` is the legacy
+        // System/Dark/Light field preserved for the Python build, and reading
+        // it here silently reset every launch to the default palette.
+        crate::theme::set_active(&settings.theme_name);
         let version = crate::cli::VERSION.to_string();
         let mut app = Self {
             state,
@@ -1170,6 +1173,29 @@ mod tests {
         assert!(app.state.find_worktree(worktree_id).is_some());
         assert_eq!(app.notifications.len(), 1);
         assert!(app.notifications[0].text.contains("worktree is locked"));
+    }
+
+    /// The regression that made themes non-sticky: startup activated the
+    /// legacy `theme` field (always "system") instead of `theme_name`, so a
+    /// saved theme applied in-session and silently reset on every launch.
+    #[tokio::test]
+    async fn startup_activates_the_saved_theme() {
+        let _guard = crate::theme::test_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = AppState::load_from(dir.path().join(".forestui-config.json"));
+        let (tx, _rx) = crate::event::start();
+        let settings = Settings {
+            theme_name: "nord".into(),
+            ..Settings::default()
+        };
+
+        let _app = App::with_state(tx, state, settings);
+        assert_eq!(
+            crate::theme::active().slug,
+            "nord",
+            "the saved theme must be active before the first frame"
+        );
+        crate::theme::set_active("forest-dark");
     }
 
     #[tokio::test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -137,6 +137,15 @@ impl EventTx {
 }
 
 /// Create the channel and start the input reader and tick timer.
+/// A bare channel for tests: no stdin-polling reader thread, no tick task.
+/// [`start`] spawns both, and every test fixture that called it added another
+/// detached thread competing for the test binary's stdin.
+#[cfg(test)]
+pub fn test_channel() -> (EventTx, UnboundedReceiver<AppEvent>) {
+    let (tx, rx) = unbounded_channel::<AppEvent>();
+    (EventTx(tx), rx)
+}
+
 pub fn start() -> (EventTx, UnboundedReceiver<AppEvent>) {
     let (tx, rx) = unbounded_channel::<AppEvent>();
 

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -796,7 +796,7 @@ impl SettingsModal {
                 .unwrap_or(0),
             opened_with_theme: theme_slug,
             theme_slug,
-            legacy_theme: settings.theme.clone(),
+            legacy_theme: settings.legacy_theme.clone(),
             branch_prefix: TextInput::new(settings.branch_prefix.clone()).with_placeholder("feat/"),
             custom_buttons: settings.custom_buttons.clone(),
             focus: Self::FOCUS_EDITOR,
@@ -816,7 +816,7 @@ impl SettingsModal {
             default_editor: EDITORS[self.editor_index].1.to_string(),
             default_terminal: String::new(),
             branch_prefix: self.branch_prefix.value().to_string(),
-            theme: self.legacy_theme.clone(),
+            legacy_theme: self.legacy_theme.clone(),
             theme_name: self.theme_slug.to_string(),
             custom_buttons: self.custom_buttons.clone(),
         }
@@ -1592,7 +1592,7 @@ mod tests {
         };
         assert_eq!(slug, crate::theme::THEMES[1].slug);
         assert_eq!(crate::theme::active().slug, slug);
-        crate::theme::set_active("forest-dark");
+        // The guard restores the pre-test theme on drop.
     }
 
     /// A previewed theme must not outlive the dialog it was previewed in:
@@ -1629,8 +1629,7 @@ mod tests {
         assert_eq!(saved.theme_name, "nord");
         // The legacy field is written back untouched — the Python build's
         // Settings dialog crashes on values outside System/Dark/Light.
-        assert_eq!(saved.theme, "system");
-        crate::theme::set_active("forest-dark");
+        assert_eq!(saved.legacy_theme, "system");
     }
 
     /// An unknown stored slug resolves to the default when the dialog opens,

--- a/src/models.rs
+++ b/src/models.rs
@@ -239,9 +239,12 @@ pub struct Settings {
     pub branch_prefix: String,
     /// The Python build's inert System/Dark/Light choice, preserved verbatim:
     /// its Settings dialog crashes on any other value, and the settings file
-    /// is shared across builds. The Rust build never reads it.
-    #[serde(default = "default_theme")]
-    pub theme: String,
+    /// is shared across builds. The Rust build never applies it — the Rust
+    /// name says so, while the on-disk key stays `"theme"` (the compat rule
+    /// governs the file format, not the identifier); reading the wrong field
+    /// for the palette is what made themes reset on every launch once.
+    #[serde(rename = "theme", default = "default_theme")]
+    pub legacy_theme: String,
     /// Slug of the named theme the Rust build applies (`theme::THEMES`).
     /// Additive and defaulted, so files from either build load in both;
     /// unknown slugs resolve to the default at activation.
@@ -257,7 +260,7 @@ impl Default for Settings {
             default_editor: default_editor(),
             default_terminal: String::new(),
             branch_prefix: default_branch_prefix(),
-            theme: default_theme(),
+            legacy_theme: default_theme(),
             theme_name: default_theme_name(),
             custom_buttons: Vec::new(),
         }

--- a/src/services/settings.rs
+++ b/src/services/settings.rs
@@ -85,7 +85,7 @@ mod tests {
         std::fs::write(&p, r#"{"default_editor": "nvim"}"#).unwrap();
         let s = load_settings_from(&p);
         assert_eq!(s.default_editor, "nvim");
-        assert_eq!(s.theme, "system");
+        assert_eq!(s.legacy_theme, "system");
         assert_eq!(s.theme_name, "forest-dark");
         assert!(s.custom_buttons.is_empty());
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -197,9 +197,10 @@ pub fn set_active(slug: &str) {
     // parallel: every mutation serializes behind the test lock so a picker
     // test's preview window cannot be clobbered by another test constructing
     // an App mid-assertion. Re-entrant per thread, so a test already holding
-    // the lock can call this freely. Compiled out of real builds.
+    // the lock can call this freely. Serialize-only — the restoring guard
+    // here would undo this very call on return. Compiled out of real builds.
     #[cfg(test)]
-    let _guard = test_lock();
+    let _guard = test_sync::serialize_only();
     let theme = by_slug(slug).unwrap_or(&THEMES[0]);
     if let Ok(mut guard) = active_cell().write() {
         *guard = theme;
@@ -359,7 +360,9 @@ pub fn action_border(focused: bool, variant: Variant, hovered: bool) -> Style {
 /// Serializes tests that touch the process-global active theme, so a preview
 /// in one test cannot race an assertion (or an `App` construction) in another.
 /// Re-entrant per thread: `set_active` takes it internally, and a test already
-/// holding it gets a no-op guard instead of deadlocking itself.
+/// holding it gets a no-op guard instead of deadlocking itself. On drop the
+/// outermost guard restores whatever theme was active when it was taken —
+/// cleanup that a panic cannot skip and no test has to remember.
 #[cfg(test)]
 pub(crate) fn test_lock() -> test_sync::ThemeGuard {
     test_sync::lock()
@@ -375,24 +378,46 @@ pub(crate) mod test_sync {
         static HELD: Cell<bool> = const { Cell::new(false) };
     }
 
-    pub struct ThemeGuard(Option<MutexGuard<'static, ()>>);
+    pub struct ThemeGuard {
+        /// The lock itself, plus the slug to put back — `None` for re-entrant
+        /// and serialize-only guards, which own neither.
+        held: Option<(MutexGuard<'static, ()>, Option<&'static str>)>,
+    }
 
     impl Drop for ThemeGuard {
         fn drop(&mut self) {
-            if self.0.is_some() {
+            if let Some((_lock, restore)) = self.held.take() {
+                if let Some(slug) = restore {
+                    // HELD is still set, so this re-enters as a no-op guard.
+                    super::set_active(slug);
+                }
                 HELD.set(false);
+                // `_lock` releases here, after the restore.
             }
         }
     }
 
+    /// The restoring flavour, for tests.
     pub fn lock() -> ThemeGuard {
+        acquire(true)
+    }
+
+    /// Serialization without restore-on-drop, for `set_active` itself.
+    pub(crate) fn serialize_only() -> ThemeGuard {
+        acquire(false)
+    }
+
+    fn acquire(restore: bool) -> ThemeGuard {
         if HELD.get() {
             // This thread already owns the lock; hand out a no-op guard.
-            return ThemeGuard(None);
+            return ThemeGuard { held: None };
         }
         let guard = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         HELD.set(true);
-        ThemeGuard(Some(guard))
+        let previous = restore.then(|| super::active().slug);
+        ThemeGuard {
+            held: Some((guard, previous)),
+        }
     }
 }
 

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -618,12 +618,12 @@ mod tests {
     fn test_app(dir: &tempfile::TempDir) -> App {
         settings_service::set_forest_path(dir.path().to_str());
         // Dropping the receiver is fine: sends are best-effort and no test reads
-        // events back.
-        let (tx, _rx) = event::start();
-        let mut app = App::new(tx, "test".into());
-        app.state = AppState::load_from(dir.path().join(".forestui-config.json"));
-        app.settings = Settings::default();
-        app
+        // events back. Explicit default settings, never `App::new`: that reads
+        // the developer's real ~/.config/forestui/settings.json and would
+        // activate their personal theme, making test rendering machine-dependent.
+        let (tx, _rx) = event::test_channel();
+        let state = AppState::load_from(dir.path().join(".forestui-config.json"));
+        App::with_state(tx, state, Settings::default())
     }
 
     fn with_repository(app: &mut App) {


### PR DESCRIPTION
Regression from #43's compat rework, caught by verifying stickiness end to end: startup still activated the **legacy** `settings.theme` field (always `"system"` → default palette) while the save path used `theme_name` — so a chosen theme worked for the session and silently reset on every launch.

One-line fix in `App::with_state` plus a regression test asserting the saved theme is active before the first frame (the test fails on the unfixed code).

tu-verified on a fresh tmux server: `"theme_name": "nord"` in settings.json → relaunch comes up in Nord. (First verification attempt re-attached to the old session still running the old binary — session persistence doing its job — hence the fresh-server re-check.)

182 tests green in both configs.