### PR TITLE
Sidebar: reveal clipped rows in a boxed hover tooltip

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,8 +43,18 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     app.sidebar_rect = sidebar_area;
     app.detail_rect = detail_area;
 
-    sidebar::draw(frame, app, sidebar_area);
+    let hover_reveal = sidebar::draw(frame, app, sidebar_area);
     detail::draw(frame, app, detail_area);
+    // Painted after the detail pane so a hovered row that is too wide for the
+    // sidebar spills its full text over the divider instead of under it.
+    // Skipped under modals: their backdrop repaints the panes anyway, and the
+    // theme picker (which keeps the panes visible as its preview) must not
+    // have a stray hover band floating through it.
+    if app.modals.is_empty()
+        && let Some(reveal) = hover_reveal
+    {
+        sidebar::draw_hover_reveal(frame, reveal);
+    }
     draw_footer(frame, app, footer_area);
     // Toasts are hidden while any modal is open — under most modals the
     // backdrop wipes them anyway; the picker skips the backdrop, so it has to
@@ -286,6 +296,69 @@ mod tests {
         assert!(
             rows_with_text > 1,
             "the notification text occupies {rows_with_text} row(s); it must wrap"
+        );
+    }
+
+    /// Hovering a row wider than the sidebar reveals the whole name across
+    /// the divider; the same row un-hovered stays clipped at the divider.
+    #[tokio::test]
+    async fn a_hovered_overlong_row_reveals_past_the_divider() {
+        use crate::app::test_support::app_with_fixture;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let long_name = "a-worktree-name-far-wider-than-the-sidebar-allows";
+        let (_dir, mut app) = app_with_fixture();
+        if let Some(crate::app::SidebarRow::Worktree { name, .. }) = app.rows.get_mut(1) {
+            *name = long_name.into();
+        } else {
+            panic!("fixture row 1 is not a worktree");
+        }
+
+        let row_text = |terminal: &Terminal<TestBackend>, row: u16| -> String {
+            let buffer = terminal.backend().buffer();
+            (0..buffer.area.width)
+                .map(|col| buffer[(col, row)].symbol().chars().next().unwrap_or(' '))
+                .collect()
+        };
+        // Header row + the 3-row gh-status box put the first tree row at y=4;
+        // the mutated worktree is the row below it.
+        let worktree_row = 5;
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("test terminal");
+        terminal.draw(|frame| draw(frame, &mut app)).expect("draw");
+        assert!(
+            !row_text(&terminal, worktree_row).contains(long_name),
+            "an un-hovered overlong row must clip at the divider"
+        );
+
+        app.hovered = Some(HitTarget::SidebarRow(1));
+        terminal.draw(|frame| draw(frame, &mut app)).expect("draw");
+        let revealed = row_text(&terminal, worktree_row);
+        let end = revealed
+            .find(long_name)
+            .expect("the hovered row must reveal its full name across the divider")
+            + long_name.len();
+        assert!(
+            revealed[end..].trim_start().starts_with('│'),
+            "the reveal must close with a right border, got: {:?}",
+            &revealed[end..]
+        );
+        // Zero horizontal shift: the left border chomps the one-cell tree
+        // angle in column 0 and everything after it keeps its column.
+        assert!(
+            revealed.starts_with("│─ "),
+            "the left border must replace the angle without shifting the text, got: {:?}",
+            &revealed[..8]
+        );
+        // The box: its border rows sit on the neighbouring lines.
+        assert!(
+            row_text(&terminal, worktree_row - 1).contains('┌'),
+            "the reveal must draw a top border above the row"
+        );
+        assert!(
+            row_text(&terminal, worktree_row + 1).contains('└'),
+            "the reveal must draw a bottom border below the row"
         );
     }
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -8,7 +8,15 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
-pub fn draw(frame: &mut Frame, app: &mut App, area: Rect) {
+/// A sidebar row wider than the sidebar, hovered: the full line and where to
+/// paint it. Returned by [`draw`] and rendered by the caller *after* the
+/// detail pane, so the revealed text wins the cells it spills onto.
+pub struct HoverReveal {
+    pub rect: Rect,
+    pub line: Line<'static>,
+}
+
+pub fn draw(frame: &mut Frame, app: &mut App, area: Rect) -> Option<HoverReveal> {
     // `#sidebar-header-box { height: 3; padding: 1 0 0 0; border-bottom: solid }`
     // — a blank row, the centred status, then the rule that closes the box.
     let [header_area, tree_area] =
@@ -34,7 +42,7 @@ pub fn draw(frame: &mut Frame, app: &mut App, area: Rect) {
             Line::from(Span::styled("Press [a] to add one", theme::muted())),
         ];
         frame.render_widget(Paragraph::new(lines), inner);
-        return;
+        return None;
     }
 
     let hovered = match app.hovered {
@@ -99,6 +107,66 @@ pub fn draw(frame: &mut Frame, app: &mut App, area: Rect) {
             );
         }
     }
+
+    // A hovered row that does not fit reveals itself in full: its line is
+    // repainted from the same left edge, spilling over the divider onto the
+    // detail pane. Mouse-only by design — keyboard users see the same names
+    // in the detail pane header when they select the row.
+    let index = hovered?;
+    let row = app.rows.get(index)?;
+    let screen_row = index.checked_sub(offset)?;
+    if screen_row >= inner.height as usize {
+        return None;
+    }
+    let line = row_line(row);
+    if line.width() <= inner.width as usize {
+        return None;
+    }
+    // The reveal is a boxed tooltip: a bordered, elevated panel centred on
+    // the hovered row, so the spilled text is unmistakably an overlay rather
+    // than words leaking into the detail pane. Three rows tall, which is why
+    // it clamps inside the body — at the tree's last row the box shifts up a
+    // row instead of drawing its bottom border over the footer.
+    if area.height < 3 {
+        return None;
+    }
+    // The left border claims column 0 instead of pushing the text right:
+    // every row shape spends that cell on a one-column glyph (the tree
+    // angle, the twisty, padding), so the border chomps it and the name
+    // keeps its columns — hovering must never make the text jump.
+    let mut spans = line.spans;
+    if let Some(first) = spans.first_mut() {
+        let mut chars = first.content.chars();
+        chars.next();
+        *first = Span::styled(chars.as_str().to_string(), first.style);
+    }
+    let line = Line::from(spans);
+    let width = (line.width() as u16).saturating_add(2);
+    let right_edge = frame.area().right();
+    let y = (inner.y + screen_row as u16)
+        .saturating_sub(1)
+        .clamp(area.y, area.bottom().saturating_sub(3));
+    Some(HoverReveal {
+        rect: Rect {
+            x: inner.x,
+            y,
+            width: width.min(right_edge.saturating_sub(inner.x)),
+            height: 3,
+        },
+        line,
+    })
+}
+
+/// Paint a [`HoverReveal`]: the full row in a bordered box, over whatever the
+/// panes drew there.
+pub fn draw_hover_reveal(frame: &mut Frame, reveal: HoverReveal) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border())
+        .style(Style::default().bg(theme::active().bg_elevated));
+    let text_area = block.inner(reveal.rect);
+    frame.render_widget(block, reveal.rect);
+    frame.render_widget(Paragraph::new(reveal.line), text_area);
 }
 
 /// Cells the `▾`/`▸` twisty and its trailing space occupy.
@@ -134,7 +202,19 @@ fn draw_gh_status(frame: &mut Frame, app: &App, area: Rect) {
 fn row_to_item(row: &SidebarRow, hovered: bool) -> ListItem<'static> {
     // `ListItem`'s own style paints the whole row, so hover reads as a band
     // across the sidebar exactly as Textual's `ListItem:hover` did.
-    let item = match row {
+    let item = ListItem::new(row_line(row));
+    if hovered {
+        item.style(Style::default().bg(theme::active().bg_hover))
+    } else {
+        item
+    }
+}
+
+/// One sidebar row as its full, unclipped line. The list clips this at the
+/// divider; the hover reveal draws it whole — both must come from here or the
+/// revealed text could disagree with the row it replaces.
+fn row_line(row: &SidebarRow) -> Line<'static> {
+    match row {
         SidebarRow::Repository {
             name,
             has_worktrees,
@@ -150,10 +230,10 @@ fn row_to_item(row: &SidebarRow, hovered: bool) -> ListItem<'static> {
                 (true, false) => "▼ ",
                 (true, true) => "▶ ",
             };
-            ListItem::new(Line::from(vec![
+            Line::from(vec![
                 Span::styled(twisty, theme::muted()),
                 Span::styled(name.clone(), theme::title()),
-            ]))
+            ])
         }
         SidebarRow::Worktree {
             name,
@@ -169,23 +249,17 @@ fn row_to_item(row: &SidebarRow, hovered: bool) -> ListItem<'static> {
             if let Some(branch) = branch {
                 spans.push(Span::styled(format!(" [{branch}]"), theme::accent()));
             }
-            ListItem::new(Line::from(spans))
+            Line::from(spans)
         }
-        SidebarRow::ArchivedHeader => ListItem::new(Line::from(Span::styled(
-            " Archived",
-            theme::section_header(),
-        ))),
+        SidebarRow::ArchivedHeader => {
+            Line::from(Span::styled(" Archived", theme::section_header()))
+        }
         SidebarRow::ArchivedWorktree {
             name, repo_name, ..
-        } => ListItem::new(Line::from(Span::styled(
+        } => Line::from(Span::styled(
             format!("   {name} ({repo_name})"),
             theme::muted(),
-        ))),
-    };
-    if hovered {
-        item.style(Style::default().bg(theme::active().bg_hover))
-    } else {
-        item
+        )),
     }
 }
 


### PR DESCRIPTION
## What

A sidebar row wider than the fixed 35 columns clips at the divider. Hovering such a row now reveals its full text in a bordered, elevated box painted over the detail pane; moving the pointer away restores the clipped row. Rows that fit produce no reveal.

## Design decisions

- **Zero horizontal shift.** The box's left border takes column 0 by chomping the one-cell glyph every row shape keeps there (the `├`/`└` tree angle, the repo twisty, archived-row padding), so the revealed name sits in exactly the columns it occupies at rest — hovering never makes text jump.
- **Single source of truth.** The revealed line comes from the same `row_line` builder the list items render from, so the reveal cannot drift from the row it replaces.
- **Immediate-mode overlay.** The reveal is returned by `sidebar::draw` and painted after the detail pane — later-draw-wins is the whole z-axis. No state to clean up: the next frame simply doesn't draw it.
- **Edges.** The 3-row box clamps inside the body (shifts up a row at the tree's bottom instead of covering the footer), clips at the screen's right edge for extreme names, skips bodies shorter than 3 rows, and is suppressed while any modal is open.

Mouse-only by design — keyboard users see the full name in the detail pane when they select the row.

## Testing

- `make check` green; new render test asserts the clipped resting state, the full-name reveal, the zero-shift property (`│─ ` prefix), and both border rows.
- Driven live with `tu`: hover reveal/retract on medium and extreme rows, screen-edge clamping.
- Full `tu-sweep` acceptance run: all cases PASS, zero baseline frame diffs (the reveal renders only on hover, which no sweep case triggers).