### PR TITLE
Create windows in our own tmux session, not the busiest one

### DIFF
--- a/doc/rust-rewrite/baseline/rust/UC-82-reattach-detached.txt
+++ b/doc/rust-rewrite/baseline/rust/UC-82-reattach-detached.txt
@@ -1,3 +1,3 @@
-bash-5.2$ ./target/release/forestui <ROOT>/forest
+bash-5.2$ <forestui> <ROOT>/forest
 [detached (from session forestui-forest-<sha>)]
 bash-5.2$

--- a/scripts/tu-sweep.sh
+++ b/scripts/tu-sweep.sh
@@ -189,11 +189,18 @@ capture() {
   local id="$1" slug="$2" sess="${3:-$SESS}"
   tu screenshot --name "$sess" --png -o "$SHOTS/$id-$slug.png" >/dev/null 2>&1
   tu screenshot --name "$sess" 2>/dev/null \
-    | ROOT="$ROOT" HOST="$(hostname)" HOST_SHORT="$(hostname -s)" WHO="$(id -un)" python3 -c '
+    | ROOT="$ROOT" HOST="$(hostname)" HOST_SHORT="$(hostname -s)" WHO="$(id -un)" \
+      FUI_BIN="${FUI_CMD[0]}" python3 -c '
 import json, os, re, sys
 root = os.environ["ROOT"]
 text = json.load(sys.stdin)["content"]
 text = text.replace(root, "<ROOT>")
+# The command line is echoed in frames that show a shell. CLAUDE.md tells you
+# to pass an absolute binary path when the tu cwd is not the repo, which would
+# otherwise put a local path — and the branch worktree it was built in — into a
+# committed frame, making the baseline depend on who ran the sweep and from
+# where.
+text = text.replace(os.environ["FUI_BIN"], "<forestui>")
 text = re.sub(r"\b[0-9a-f]{7}\b", "<sha>", text)
 # Bare or parenthesised: session cards and issue rows print "N days ago"
 # with no parentheses, and an unmasked one rots the committed frames daily.

--- a/src/services/tmux.rs
+++ b/src/services/tmux.rs
@@ -28,66 +28,68 @@ fn tmux(args: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// The session of the most recently active tmux client.
+/// The tmux session forestui creates its windows in.
 ///
-/// Not cached: the active client changes between grouped sessions, because the
-/// user may be viewing forestui from any terminal.
+/// Resolved from `TMUX_PANE`, which names this process's own pane and so is
+/// exact. This used to ask `list-clients` for the most recently active client
+/// on the server, filtered by session group — but a session `ensure_tmux`
+/// creates on first launch is not in a group at all (the grouped session is
+/// only made when the base session already existed), so `session_group` came
+/// back empty, the filter went inert, and the scan returned whichever session
+/// the user had touched last. A second forestui, opened on a different forest,
+/// therefore created its windows in the first one's session.
+///
+/// Sessions in a group genuinely share their windows, so there any member is a
+/// correct target; the activity scan still runs in that case, so the window
+/// opens in whichever terminal the user is actually looking at.
 pub fn current_session() -> Option<String> {
     if !is_inside_tmux() {
         return None;
     }
 
-    // Only consider clients attached to sessions in our own group.
-    let our_group = tmux(&["display-message", "-p", "#{session_group}"])
+    let pane = std::env::var("TMUX_PANE").ok()?;
+    let own = tmux(&["display-message", "-p", "-t", &pane, "#{session_id}"])?
+        .trim()
+        .to_string();
+    if own.is_empty() {
+        return None;
+    }
+
+    let group = tmux(&["display-message", "-p", "-t", &pane, "#{session_group}"])
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
+    if group.is_empty() {
+        return Some(own);
+    }
 
-    if let Some(out) = tmux(&[
+    let clients = tmux(&[
         "list-clients",
         "-F",
         "#{client_activity} #{session_id} #{session_group}",
-    ]) {
-        let mut best_id: Option<String> = None;
-        let mut best_time: i64 = -1;
-        for line in out.lines() {
-            let parts: Vec<&str> = line.trim().splitn(3, ' ').collect();
-            if parts.len() != 3 {
-                continue;
-            }
-            let Ok(activity) = parts[0].parse::<i64>() else {
-                continue;
-            };
-            if !our_group.is_empty() && parts[2] != our_group {
-                continue;
-            }
-            if activity > best_time {
-                best_time = activity;
-                best_id = Some(parts[1].to_string());
-            }
-        }
-        if best_id.is_some() {
-            return best_id;
-        }
-    }
+    ])
+    .unwrap_or_default();
+    Some(most_active_in_group(&clients, &group, &own))
+}
 
-    // Fallback: first attached session, then any session.
-    if let Some(out) = tmux(&["list-sessions", "-F", "#{session_id} #{session_attached}"]) {
-        let mut first: Option<String> = None;
-        for line in out.lines() {
-            let mut parts = line.trim().split(' ');
-            let (Some(id), Some(attached)) = (parts.next(), parts.next()) else {
-                continue;
-            };
-            if first.is_none() {
-                first = Some(id.to_string());
-            }
-            if attached.parse::<i64>().unwrap_or(0) > 0 {
-                return Some(id.to_string());
-            }
+/// Of the clients attached to our own session group, the session of the most
+/// recently active one — falling back to our own session. Pure, for testing.
+fn most_active_in_group(clients: &str, group: &str, own: &str) -> String {
+    let mut best = own.to_string();
+    let mut best_activity = i64::MIN;
+    for line in clients.lines() {
+        let parts: Vec<&str> = line.trim().splitn(3, ' ').collect();
+        if parts.len() != 3 || parts[2] != group {
+            continue;
         }
-        return first;
+        let Ok(activity) = parts[0].parse::<i64>() else {
+            continue;
+        };
+        if activity > best_activity {
+            best_activity = activity;
+            best = parts[1].to_string();
+        }
     }
-    None
+    best
 }
 
 /// The tmux window this process is running in.
@@ -279,6 +281,34 @@ pub fn create_claude_window(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The bug this replaced: a forestui opened on a second forest created its
+    /// windows in the *first* forestui's session, because ungrouped sessions
+    /// report an empty group and the scan then ranged over the whole server,
+    /// returning whichever terminal the user had touched most recently.
+    #[test]
+    fn a_client_outside_our_group_never_wins() {
+        let clients = "100 $1 ours\n900 $2 someone-else\n300 $3 ours\n";
+        assert_eq!(most_active_in_group(clients, "ours", "$9"), "$3");
+    }
+
+    /// An ungrouped session short-circuits before this is reached, but a group
+    /// whose clients have all detached must still answer with our own session
+    /// rather than someone else's.
+    #[test]
+    fn our_own_session_is_the_fallback() {
+        assert_eq!(most_active_in_group("900 $2 other\n", "ours", "$7"), "$7");
+        assert_eq!(most_active_in_group("", "ours", "$7"), "$7");
+        assert_eq!(most_active_in_group("garbage\n", "ours", "$7"), "$7");
+    }
+
+    /// Within our own group the windows are shared, so the most recently active
+    /// client is the right one: the window opens where the user is looking.
+    #[test]
+    fn the_most_recently_active_client_in_our_group_wins() {
+        let clients = "100 $1 ours\n500 $2 ours\n300 $3 ours\n";
+        assert_eq!(most_active_in_group(clients, "ours", "$1"), "$2");
+    }
 
     #[test]
     fn tui_editor_detection() {

--- a/src/services/tmux.rs
+++ b/src/services/tmux.rs
@@ -42,6 +42,12 @@ fn tmux(args: &[&str]) -> Option<String> {
 /// Sessions in a group genuinely share their windows, so there any member is a
 /// correct target; the activity scan still runs in that case, so the window
 /// opens in whichever terminal the user is actually looking at.
+///
+/// There is deliberately no fallback for a missing `TMUX_PANE`. The previous
+/// implementation ended in "first attached session, else any session", and
+/// guessing is what put windows in the wrong forestui: a caller that cannot
+/// identify its own pane cannot identify its own session either, and failing
+/// the action visibly beats acting on somebody else's session.
 pub fn current_session() -> Option<String> {
     if !is_inside_tmux() {
         return None;


### PR DESCRIPTION
## The bug

Running a second forestui on a different forest creates its windows in the
**first** forestui's tmux session. Press `t` in the new instance and the
terminal opens in the session you were already working in — as do editors,
file managers and Claude windows.

It is worse than misplacement: `find_window` is scoped the same way, so
`create_editor_window` could find an `edit:<name>` window in the *other*
session and `select-window` it, yanking the session you were working in over
to a different window.

## Root cause

`current_session()` did not ask "which session am I in?". It asked
`list-clients` for **the most recently active client on the server**, then
filtered by session group:

```rust
if !our_group.is_empty() && parts[2] != our_group {
    continue;
}
```

Two things collapse together:

1. `ensure_tmux` only builds a **grouped** session when the base session
   already existed. The first launch on a new forest creates the base session
   and attaches straight to it, so that session is **ungrouped** and
   `#{session_group}` is empty.
2. With an empty group the filter is skipped entirely, so the scan ranges over
   every client on the server.

The answer is then "whichever session the user touched last" — in practice
their main forestui, because that is the one they are working in.

Confirmed on an isolated server with two ungrouped sessions:

```
our_group=[]
activity=1787338278 session=PROD group=[]
activity=1787338280 session=TEST group=[]
```

## The fix

`TMUX_PANE` names this process's own pane, so it answers the question exactly —
the same approach `current_window()` already used.

Grouped sessions genuinely do share their windows, so there any member is a
correct target and the activity scan is still the right call: it opens the
window in whichever terminal the user is actually looking at. That path is
kept, now confined to our own group with our own session as the floor.

There is deliberately no fallback for a missing `TMUX_PANE`. The old code ended
in "first attached session, else any session", and guessing is what caused
this. A caller that cannot identify its own pane cannot identify its own
session either, and failing the action visibly beats acting on someone else's
session.

## Reproduction

Two forests, one server, pressing `t` in the second instance:

```
before   fA: 1:forestui-dev-1554  2:term:repo     <- opened from fB, landed here
         fB: 1:forestui-dev-1554
after    fA: 1:forestui-dev-1554
         fB: 1:forestui-dev-1554  2:term:repo     <- lands where it was asked
```

## Second commit

The frame normaliser in `tu-sweep.sh` masks host, user, root and pids because
the frames are committed and travel to a public PR — but not the forestui
command itself. Passing an absolute binary path, which CLAUDE.md tells you to
do when the tu working directory is not the repo, wrote a local path and the
branch worktree it was built in into UC-82's committed frame. Baseline
refreshed in the same commit, since the frame genuinely changed.

## Testing

- `make check` — 199 tests
- 3 new unit tests over the group choice: a client outside our group never
  wins, our own session is the fallback, most-recent-in-group wins
- `scripts/tu-sweep.sh` — 19 assertions pass, zero baseline drift. **UC-81**
  matters most here: it drives two terminals on one forest through grouped
  sessions, which is the path this change could have broken
  (`both-see-same-window-count=5`, `terminal-a-stayed-put=0`)
