### PR TITLE
Reset the terminal input modes on every exit, not just the tidy one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,33 @@ window instead.
 There is deliberately no off switch, per window or global. Installed means the
 two names agree; not wanting that is an uninstall.
 
+### Terminal input modes
+
+forestui asks the terminal for five DEC private modes (`src/terminal.rs`):
+mouse buttons, drag, any-motion, SGR coordinates, focus reporting. They are
+*terminal* state, not process state, so every way out of the process has to put
+them back. `src/terminal.rs` documents the four paths that do — the guard's
+`Drop`, a chained panic hook, a signal handler, and OFF-before-ON at startup,
+which heals whatever a `SIGKILL`ed run left behind. A mode added to `MODES_ON`
+fails a test until `MODES_OFF` covers it too.
+
+Two of the five are optional, because each costs something inside tmux.
+`?1003h` (any-motion) is what hover needs; `?1004h` plus tmux's server-wide
+`focus-events` is what refresh-on-return needs. tmux cancels a pending prefix
+on any key it cannot find in the `prefix` table, and a mouse or focus report is
+such a key — so with these modes on, a pointer move or a focus change landing
+between the prefix and the next key eats the command. Neither event has a key
+name to bind in tmux 3.4, so taking the mode away is the only defence, which is
+what `--no-hover` and `--no-focus-events` are. Both must stay in
+`self_command`, or the tmux re-exec silently drops them.
+
+`focus-events` is a **server** option: turning it on reaches every session and
+client on that server, and it used to stay on long after forestui exited.
+`App::release_tmux_options` puts it back. Ownership is recorded in a tmux user
+option rather than in memory, so a run that is killed before its cleanup does
+not strand the setting forever — the next run adopts it and hands it back. A
+user who set the option themselves keeps it, marker absent.
+
 ### Self-update
 forestui keeps itself current the way the Python build did — automatically, on
 launch — but never on the UI thread. `App::check_for_update` spawns the check
@@ -401,6 +428,14 @@ Unit tests live beside the code in `#[cfg(test)] mod tests` and run with
 `make test`. Async code uses `#[tokio::test]`. Rendering is tested against
 `ratatui::backend::TestBackend`, which renders into an in-memory buffer you can
 assert on.
+
+**Terminal handover:** `scripts/terminal-modes-probe.py` runs the built binary
+on a private pty, kills it every way that used to leak the input modes, and
+asserts the reset arrived — plus that raw mode and the alternate screen were
+undone and the exit status still reports the signal. Unit tests can pin the
+mode strings and the guard's `Drop`; only a real terminal can show what a
+signal handler actually emitted. Run it after touching `src/terminal.rs`; it
+isolates itself (own forest, own `TMUX_TMPDIR`) and cleans up.
 
 **Visual/behavioural verification:** forestui is a TUI app — lint, typecheck and
 unit tests alone cannot catch visual bugs, wrong window names, broken

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "libc",
  "ratatui",
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,12 @@ tokio = { version = "1", features = [
 ] }
 uuid = { version = "1.24.0", features = ["v4", "serde"] }
 
+# Signal handlers. Resetting the terminal when a pane is killed has to happen
+# inside the handler itself, and the async-signal-safe primitives that allows
+# (`write`, `tcsetattr`, `raise`) are not in std.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ forestui ~/my-projects
 
 # Show help
 forestui --help
+
+# Stop asking the terminal to report pointer movement, or focus changes
+# (see "If tmux's prefix key stops working")
+forestui --no-hover
+forestui --no-focus-events
 ```
 
 ### Keyboard Shortcuts
@@ -154,6 +159,26 @@ crosses them, so what is clickable is visible rather than guessed at:
 - **The scroll wheel** scrolls whichever pane the pointer is over, whether or
   not it holds the keyboard focus.
 - **The scrollbar** can be dragged, and clicking its track pages to that point.
+
+### If tmux's prefix key stops working
+
+tmux drops a pending prefix when the next thing it receives is a key it cannot
+find in its `prefix` key table, and a mouse or focus report is such a key. So
+`C-a` followed by one of those silently does nothing, and the key you typed
+after it is lost.
+
+forestui asks the terminal for two reports that can land in that gap. Either
+can be turned off:
+
+| Flag | You lose | The prefix stops being eaten by |
+|------|----------|---------------------------------|
+| `--no-hover` | controls no longer light up under the pointer; clicks, wheel and drag still work | pointer movement (`?1003h`), while forestui's pane is active |
+| `--no-focus-events` | no refresh the moment you return to the window — `r` and the 30-second sweep still do it | focus changes, in every window on that tmux server |
+
+`focus-events` is a tmux *server* option, and forestui turns it on. It hands it
+back on exit, including after a run that was killed before it could — but if
+your own tmux config turns it on, it stays on and the flag cannot help with
+that half.
 
 ### TUI Editor Integration
 

--- a/scripts/terminal-modes-probe.py
+++ b/scripts/terminal-modes-probe.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Check that forestui hands the terminal back however it is killed.
+
+`src/terminal.rs` turns on five input modes and has to turn them off again on
+every exit the OS lets it observe. A unit test can prove the *strings* are
+right and that the guard drops; it cannot prove the process actually emitted
+them when a signal arrived, or that raw mode was undone, because both are
+properties of a real terminal.
+
+So this runs forestui on a private pty, captures every byte it writes there,
+kills it in each of the ways that used to leak (issue #51), and asserts the
+reset arrived. Run it after touching anything in `src/terminal.rs`:
+
+    scripts/terminal-modes-probe.py [path-to-forestui]
+
+Isolation: the child gets its own throwaway forest directory, `TMUX_TMPDIR`
+pointing at an empty directory, and `TMUX` set so it does not re-execute into
+tmux. Any tmux command it runs can therefore only reach a server inside that
+throwaway directory — never the one the user is working in.
+"""
+
+import fcntl
+import os
+import pty
+import select
+import signal
+import subprocess
+import sys
+import shutil
+import tempfile
+import termios
+import time
+
+MODES_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1004h"
+MODES_OFF = "\x1b[?1004l\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l"
+ALT_SCREEN_OFF = "\x1b[?1049l"
+
+DEFAULT_BINARY = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "target",
+    "release",
+    "forestui",
+)
+
+
+class Run:
+    """One forestui process on a pty of its own."""
+
+    def __init__(self, forest, tmux_dir, extra_args=()):
+        self.master, slave = pty.openpty()
+
+        def preexec():
+            os.setsid()
+            fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+
+        env = dict(
+            os.environ,
+            TERM="xterm-256color",
+            TMUX=os.path.join(tmux_dir, "no-such-socket,0,0"),
+            TMUX_TMPDIR=tmux_dir,
+        )
+        self.proc = subprocess.Popen(
+            [BINARY, "--no-self-update", *extra_args, forest],
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            preexec_fn=preexec,
+            env=env,
+            close_fds=True,
+        )
+        os.close(slave)
+        self.written = ""
+
+    def drain(self, seconds):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            ready, _, _ = select.select([self.master], [], [], 0.05)
+            if not ready:
+                continue
+            try:
+                chunk = os.read(self.master, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            self.written += chunk.decode("utf8", "replace")
+
+    def stop(self, how):
+        how(self.proc)
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+        self.drain(1.0)
+
+    def echo_restored(self):
+        """Raw mode is terminal state too — a killed forestui that does not put
+        the settings back leaves the shell behind it with no echo."""
+        return bool(termios.tcgetattr(self.master)[3] & termios.ECHO)
+
+    def after_the_modes_were_set(self):
+        """Everything written after the last time the modes went on."""
+        if MODES_ON not in self.written:
+            return self.written
+        return self.written[self.written.rindex(MODES_ON) + len(MODES_ON) :]
+
+    def close(self):
+        os.close(self.master)
+
+
+results = []
+
+
+def check(name, ok, detail=""):
+    results.append(ok)
+    print(f"{'PASS' if ok else 'FAIL'}  {name}{' -- ' + detail if detail else ''}")
+
+
+SCRATCH = []
+
+
+def start(extra_args=()):
+    forest = tempfile.mkdtemp(prefix="forestui-probe-forest.")
+    tmux_dir = tempfile.mkdtemp(prefix="forestui-probe-tmux.")
+    SCRATCH.extend((forest, tmux_dir))
+    run = Run(forest, tmux_dir, extra_args)
+    run.drain(2.0)
+    return run
+
+
+def main():
+    # SIGKILL cannot be caught, so the next launch is what heals the terminal:
+    # startup resets every mode before asking for any.
+    run = start()
+    first = run.written
+    run.stop(lambda p: p.send_signal(signal.SIGKILL))
+    run.close()
+    reset_at = first.find(MODES_OFF)
+    set_at = first.find(MODES_ON)
+    check(
+        "startup resets the modes before setting them",
+        0 <= reset_at < set_at,
+        f"reset at {reset_at}, set at {set_at}",
+    )
+
+    for name, sig in [
+        ("SIGTERM", signal.SIGTERM),
+        ("SIGHUP", signal.SIGHUP),
+        ("SIGINT", signal.SIGINT),
+    ]:
+        run = start()
+        if MODES_ON not in run.written:
+            check(f"{name}: forestui asked for the modes at all", False)
+            run.close()
+            continue
+        run.stop(lambda p, s=sig: p.send_signal(s))
+        tail = run.after_the_modes_were_set()
+        check(f"{name}: modes off", MODES_OFF in tail)
+        check(f"{name}: alternate screen left", ALT_SCREEN_OFF in tail)
+        check(f"{name}: echo restored", run.echo_restored())
+        check(
+            f"{name}: exit status honest",
+            run.proc.returncode == -sig,
+            f"returncode {run.proc.returncode}",
+        )
+        run.close()
+
+    # The path that always worked, so a fix cannot quietly break it.
+    run = start()
+    run.stop(lambda p: os.write(run.master, b"q"))
+    check("normal quit: modes off", MODES_OFF in run.after_the_modes_were_set())
+    check(
+        "normal quit: alternate screen left",
+        ALT_SCREEN_OFF in run.after_the_modes_were_set(),
+    )
+    run.close()
+
+    print()
+    print("all passed" if all(results) else "FAILURES PRESENT")
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    BINARY = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_BINARY
+    if not os.path.exists(BINARY):
+        sys.exit(f"no forestui at {BINARY} — build it first, or pass its path")
+    try:
+        code = main()
+    finally:
+        for directory in SCRATCH:
+            shutil.rmtree(directory, ignore_errors=True)
+    sys.exit(code)

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -2,7 +2,7 @@
 
 use super::{Action, App, DetailItem, Field, Focus, PAGE_STEP};
 use crate::modal::{AddRepositoryModal, Modal, SettingsModal};
-use crate::ui::widgets::TextInput;
+use crate::ui::widgets::{TextInput, is_plain_press};
 
 /// Every key binding, in the order the footer renders them: `q` is declared
 /// first in the Python bindings but carried `priority=True`, which sorted it
@@ -122,7 +122,9 @@ impl App {
             _ => {}
         }
 
-        if let KeyCode::Char(binding) = key.code {
+        if let KeyCode::Char(binding) = key.code
+            && is_plain_press(key)
+        {
             self.run_binding(binding);
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -197,6 +197,12 @@ pub struct App {
     /// Whether to check for a newer release at startup; `--no-self-update`
     /// clears it.
     pub self_update: bool,
+    /// Which optional terminal input modes this run asked for; `--no-hover`
+    /// and `--no-focus-events` narrow it.
+    pub input_modes: crate::terminal::InputModes,
+    /// Whether *this* run turned tmux's server-wide `focus-events` on, and so
+    /// has to turn it off again on the way out.
+    focus_events_owned: bool,
 
     /// The detail items as the last frame drew them, each with whether it was
     /// enabled. Activation — a click or Enter — resolves against this snapshot
@@ -273,6 +279,8 @@ impl App {
             scroll_drag: None,
             collapsed: std::collections::HashSet::new(),
             self_update: true,
+            input_modes: crate::terminal::InputModes::default(),
+            focus_events_owned: false,
             drawn_items: Vec::new(),
             name_input: TextInput::new(""),
             branch_input: TextInput::new(""),
@@ -303,12 +311,33 @@ impl App {
         }
     }
 
+    /// Undo the global tmux state this run turned on.
+    ///
+    /// Called from the main loop's exit; a `SIGTERM` still skips it, which is
+    /// the same gap every tmux command has and not one a signal handler can
+    /// close (spawning a process from one is not async-signal-safe).
+    pub fn release_tmux_options(&mut self) {
+        if std::mem::take(&mut self.focus_events_owned) {
+            tmux::disable_focus_events();
+        }
+    }
+
     // ------------------------------------------------------------------ startup
 
     /// Work kicked off once the terminal is up.
     pub fn on_start(&mut self) {
-        if !tmux::ensure_focus_events() {
-            self.notify("Could not enable focus events", Severity::Warning);
+        if self.input_modes.focus {
+            match tmux::ensure_focus_events() {
+                tmux::FocusEvents::Ours => self.focus_events_owned = true,
+                tmux::FocusEvents::AlreadyOn => {}
+                tmux::FocusEvents::Unavailable => {
+                    self.notify("Could not enable focus events", Severity::Warning);
+                }
+            }
+        } else {
+            // Declining the mode also means clearing one a killed run left on:
+            // the flag exists for people whose prefix key it is eating.
+            tmux::release_stranded_focus_events();
         }
         if self.state.selection.repository_id.is_none()
             && let Some(first) = self.state.repositories().first()
@@ -1226,11 +1255,21 @@ pub(crate) mod test_support {
             state: KeyEventState::NONE,
         }
     }
+
+    /// The same key with `Ctrl` held — what a pane is handed when tmux sends
+    /// the prefix through, and what the app must not act on.
+    pub fn ctrl(code: ratatui::crossterm::event::KeyCode) -> ratatui::crossterm::event::KeyEvent {
+        use ratatui::crossterm::event::KeyModifiers;
+        ratatui::crossterm::event::KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            ..key(code)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::test_support::{app_with_fixture, key};
+    use super::test_support::{app_with_fixture, ctrl, key};
     use super::*;
     use crate::models::{CustomClaudeButton, Repository, Worktree};
     use ratatui::crossterm::event::KeyCode;
@@ -1379,6 +1418,30 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('q')));
         assert!(app.should_quit);
+    }
+
+    /// Defect B of issue #51: every binding fired on `Ctrl`+letter, so a
+    /// `Ctrl+A` that reached the pane — which is exactly what tmux's own
+    /// `bind C-a send-prefix` does — opened Add Repository, and `Ctrl+D`
+    /// started deleting a worktree. `Ctrl+C` stays quit.
+    #[tokio::test]
+    async fn control_modified_keys_never_fire_footer_bindings() {
+        let (_dir, mut app) = app_with_fixture();
+        let archived_before = app.state.show_archived;
+
+        for binding in ['a', 's', 'w', 'A', 'q'] {
+            app.handle_key(ctrl(KeyCode::Char(binding)));
+        }
+
+        assert!(app.modals.is_empty(), "a Ctrl combination opened a modal");
+        assert!(!app.should_quit, "Ctrl+Q quit the app");
+        assert_eq!(
+            app.state.show_archived, archived_before,
+            "Ctrl+A toggled the archived section"
+        );
+
+        app.handle_key(ctrl(KeyCode::Char('c')));
+        assert!(app.should_quit, "Ctrl+C no longer quits");
     }
 
     #[tokio::test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,25 @@ pub struct Args {
     #[arg(long = "dev")]
     pub dev_mode: bool,
 
+    /// Stop asking the terminal to report pointer movement (`?1003h`).
+    ///
+    /// Controls stop lighting up under the pointer; clicks, the wheel and
+    /// drags still work. The escape hatch for tmux users: while forestui's
+    /// pane is active, a pointer move that lands between the prefix key and
+    /// the next key cancels the tmux command (issue #51).
+    #[arg(long = "no-hover")]
+    pub no_hover: bool,
+
+    /// Stop asking for focus reporting, and leave tmux's `focus-events` alone.
+    ///
+    /// forestui no longer refreshes sessions and worktrees the moment you
+    /// come back to its window — the 30s sweep and `r` still do. `focus-events`
+    /// is a *server* option, so turning it on reaches every window on that
+    /// tmux server, where each focus change becomes an input event that can
+    /// cancel a pending prefix (issue #51).
+    #[arg(long = "no-focus-events")]
+    pub no_focus_events: bool,
+
     /// Manage the Claude Code plugin that names a session after its tmux
     /// window. Reports what it would touch and exits without starting the UI,
     /// so the install can be inspected before it happens.
@@ -49,6 +68,19 @@ pub enum ClaudePluginAction {
     Status,
     Install,
     Uninstall,
+}
+
+impl Args {
+    /// Which optional terminal input modes these arguments ask for.
+    ///
+    /// Lives here rather than in `main` so a swapped pair is a failing test
+    /// rather than a flag that silently turns off the other feature.
+    pub fn input_modes(&self) -> crate::terminal::InputModes {
+        crate::terminal::InputModes {
+            hover: !self.no_hover,
+            focus: !self.no_focus_events,
+        }
+    }
 }
 
 /// tmux window name for this instance.
@@ -93,6 +125,12 @@ fn self_command(args: &Args, program: &Path) -> String {
     }
     if args.dev_mode {
         parts.push("--dev".into());
+    }
+    if args.no_hover {
+        parts.push("--no-hover".into());
+    }
+    if args.no_focus_events {
+        parts.push("--no-focus-events".into());
     }
     if let Some(path) = &args.forest_path {
         parts.push(shell_quote(path));
@@ -257,12 +295,19 @@ mod tests {
             no_self_update: true,
             debug_mode: false,
             dev_mode: true,
+            no_hover: true,
+            no_focus_events: false,
             claude_plugin: None,
         };
         let command = self_command(&args, Path::new("/usr/local/bin/forestui"));
         assert!(command.starts_with("/usr/local/bin/forestui"));
         assert!(command.contains("--no-self-update"));
         assert!(command.contains("--dev"));
+        assert!(
+            command.contains("--no-hover"),
+            "a flag the re-exec drops is a flag that does nothing"
+        );
+        assert!(!command.contains("--no-focus-events"));
         assert!(!command.contains("--debug"));
         assert!(command.contains("'/tmp/my forest'"));
     }
@@ -270,6 +315,41 @@ mod tests {
     /// `--claude-plugin` reports and exits before anything re-executes into
     /// tmux. Carrying it through would hand the new process the same one-shot
     /// action, which exits and re-executes again — a loop that never draws a UI.
+    /// Each flag takes away exactly its own mode. They are near-identical
+    /// booleans one negation apart, so a swap would leave `--no-hover` quietly
+    /// turning off focus reporting instead.
+    #[test]
+    fn each_flag_declines_only_its_own_mode() {
+        let args = |no_hover, no_focus_events| Args {
+            forest_path: None,
+            no_self_update: false,
+            debug_mode: false,
+            dev_mode: false,
+            no_hover,
+            no_focus_events,
+            claude_plugin: None,
+        };
+
+        assert_eq!(
+            args(false, false).input_modes(),
+            crate::terminal::InputModes::default()
+        );
+        assert_eq!(
+            args(true, false).input_modes(),
+            crate::terminal::InputModes {
+                hover: false,
+                focus: true
+            }
+        );
+        assert_eq!(
+            args(false, true).input_modes(),
+            crate::terminal::InputModes {
+                hover: true,
+                focus: false
+            }
+        );
+    }
+
     #[test]
     fn a_one_shot_action_is_not_carried_into_the_re_exec() {
         let args = Args {
@@ -277,6 +357,8 @@ mod tests {
             no_self_update: false,
             debug_mode: false,
             dev_mode: false,
+            no_hover: false,
+            no_focus_events: false,
             claude_plugin: Some(ClaudePluginAction::Install),
         };
         let command = self_command(&args, Path::new("/usr/local/bin/forestui"));
@@ -293,6 +375,8 @@ mod tests {
             no_self_update: false,
             debug_mode: false,
             dev_mode: false,
+            no_hover: false,
+            no_focus_events: false,
             claude_plugin: None,
         };
         let command = self_command(&args, Path::new("/tmp/my dir/forestui"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod modal;
 mod models;
 mod services;
 mod state;
+mod terminal;
 mod theme;
 mod ui;
 mod util;
@@ -38,7 +39,7 @@ fn main() -> anyhow::Result<()> {
         .enable_all()
         .build()?;
 
-    let result = runtime.block_on(run(!args.no_self_update));
+    let result = runtime.block_on(run(!args.no_self_update, args.input_modes()));
 
     if let Err(error) = &result {
         report_crash(error);
@@ -118,13 +119,19 @@ fn run_claude_plugin_action(action: cli::ClaudePluginAction) -> anyhow::Result<(
     result.map_err(|e| anyhow::anyhow!(e))
 }
 
-async fn run(self_update: bool) -> anyhow::Result<()> {
+async fn run(self_update: bool, modes: terminal::InputModes) -> anyhow::Result<()> {
     let (tx, mut rx) = event::start();
     let mut app = App::new(tx, cli::VERSION.to_string());
     app.self_update = self_update;
+    app.input_modes = modes;
 
-    let mut terminal = ratatui::init();
-    enable_mouse();
+    // Armed before `ratatui::init()` enables raw mode, so the settings the
+    // handler restores are the ones the user's shell had.
+    terminal::install_signal_handlers();
+    let mut ui_terminal = ratatui::init();
+    // After `init`, so this hook runs ahead of ratatui's screen restore.
+    terminal::chain_panic_hook();
+    let mode_guard = terminal::ModeGuard::enable(std::io::stdout(), modes);
     app.on_start();
 
     let outcome = loop {
@@ -132,7 +139,7 @@ async fn run(self_update: bool) -> anyhow::Result<()> {
         // screen — pointer motion inside one control is the common case.
         if app.redraw {
             app.redraw = false;
-            if let Err(error) = terminal.draw(|frame| ui::draw(frame, &mut app)) {
+            if let Err(error) = ui_terminal.draw(|frame| ui::draw(frame, &mut app)) {
                 break Err(anyhow::Error::from(error));
             }
         }
@@ -148,42 +155,13 @@ async fn run(self_update: bool) -> anyhow::Result<()> {
         }
     };
 
-    disable_mouse();
+    // Explicit on the way out so the modes are reset before the screen is,
+    // matching the order every other exit path produces. The guard is what
+    // makes the paths that never reach this line safe.
+    app.release_tmux_options();
+    drop(mode_guard);
     ratatui::restore();
     outcome
-}
-
-/// Turn on mouse reporting for button presses, the wheel, and pointer motion.
-///
-/// `?1003h` (any-motion) is what makes hover possible at all: without it the
-/// terminal never reports a bare move, so no control can light up under the
-/// pointer. It was previously left off because every motion report woke the
-/// loop and repainted, which read as the app flickering under a moving mouse.
-/// That is fixed at the source instead — `App::handle_mouse` only marks the
-/// frame dirty when the *hovered target changes*, so crossing a control costs
-/// one repaint and sliding around inside it costs none.
-///
-/// `?1006h` asks for SGR coordinates so columns past 223 still resolve.
-///
-/// `?1004h` asks for focus reporting, and without it the terminal never sends
-/// focus in/out at all — so `Event::FocusGained` never arrived and everything
-/// hung off it was dead code. `ensure_focus_events` turning on tmux's
-/// `focus-events` is only half of the handshake: tmux forwards the sequences
-/// to a pane that asked for them, and this is the asking.
-/// Kept as one string so a test can pin it: a mode dropped from here fails
-/// silently and takes a whole feature with it, which is how focus reporting
-/// went missing and left `Event::FocusGained` unable to fire at all.
-const TERMINAL_MODES_ON: &str = "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1004h";
-const TERMINAL_MODES_OFF: &str = "\x1b[?1004l\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
-
-fn enable_mouse() {
-    print!("{TERMINAL_MODES_ON}");
-    let _ = std::io::stdout().flush();
-}
-
-fn disable_mouse() {
-    print!("{TERMINAL_MODES_OFF}");
-    let _ = std::io::stdout().flush();
 }
 
 /// Mirror the Textual build's crash handling: write a log, print it, and pause
@@ -199,35 +177,4 @@ fn report_crash(error: &anyhow::Error) {
     let _ = std::io::stderr().flush();
     let mut discard = String::new();
     let _ = std::io::stdin().read_line(&mut discard);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Both of these are load-bearing and neither fails loudly.
-    ///
-    /// Without `?1003h` the terminal never reports a bare pointer move, so
-    /// hover cannot work. Without `?1004h` it never reports focus at all, so
-    /// `Event::FocusGained` never arrives and everything hanging off it —
-    /// refreshing sessions and worktrees when the user comes back — is dead
-    /// code that still compiles and still has passing tests.
-    #[test]
-    fn the_terminal_modes_we_depend_on_are_requested() {
-        for (mode, why) in [
-            ("?1003h", "any-motion, for hover"),
-            ("?1004h", "focus reporting, for refresh on return"),
-            ("?1006h", "SGR coordinates, for columns past 223"),
-        ] {
-            assert!(
-                TERMINAL_MODES_ON.contains(mode),
-                "{mode} ({why}) is not requested"
-            );
-            let off = mode.replace('h', "l");
-            assert!(
-                TERMINAL_MODES_OFF.contains(&off),
-                "{mode} ({why}) is requested but never turned off"
-            );
-        }
-    }
 }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -10,7 +10,7 @@ use crate::models::{
     MAX_CLAUDE_COMMAND_LENGTH, Repository, Settings, derive_prefix, validate_button_label,
     validate_button_prefix, validate_claude_command,
 };
-use crate::ui::widgets::TextInput;
+use crate::ui::widgets::{TextInput, is_plain_press, text_input_claims};
 use crate::util;
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use std::path::PathBuf;
@@ -151,6 +151,14 @@ pub enum Modal {
 
 impl Modal {
     pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome {
+        // Every modal below matches letter shortcuts on `KeyCode::Char` alone,
+        // so without this `Ctrl+D` deleted a custom button and `Ctrl+Y`
+        // answered a confirmation. Only the combinations a focused text field
+        // claims get through — see `widgets::is_plain_press`.
+        if matches!(key.code, KeyCode::Char(_)) && !is_plain_press(key) && !text_input_claims(key) {
+            return ModalOutcome::None;
+        }
+
         match self {
             Modal::AddRepository(m) => m.handle_key(key),
             Modal::AddWorktree(m) => m.handle_key(key),
@@ -1418,6 +1426,13 @@ mod tests {
         }
     }
 
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            ..key(code)
+        }
+    }
+
     fn typed(text: &str) -> Vec<KeyEvent> {
         text.chars().map(|c| key(KeyCode::Char(c))).collect()
     }
@@ -1603,6 +1618,45 @@ mod tests {
             modal.handle_key(key(KeyCode::Char('s'))),
             ModalOutcome::Submit(ModalResult::CustomButtonsSaved(_))
         ));
+    }
+
+    /// The funnel in `Modal::handle_key`, for the same reason as the footer
+    /// bindings (Defect B of issue #51): the modals match shortcuts on the
+    /// character alone, so `Ctrl+D` used to delete the selected custom button.
+    /// The one exception is the text editor's own `Ctrl+U`, which must still
+    /// reach a focused field.
+    #[test]
+    fn modified_letters_never_fire_modal_shortcuts() {
+        let make = |name: &str| CustomClaudeButton {
+            label: name.into(),
+            prefix: name.to_lowercase(),
+            command: "claude".into(),
+        };
+        let mut modal = Modal::CustomButtons(CustomButtonsModal::new(vec![make("A"), make("B")]));
+        for shortcut in ['d', 'a', 's', 'K', 'J'] {
+            assert!(matches!(
+                modal.handle_key(ctrl(KeyCode::Char(shortcut))),
+                ModalOutcome::None
+            ));
+        }
+        let Modal::CustomButtons(buttons) = &modal else {
+            unreachable!("the modal was replaced");
+        };
+        assert_eq!(buttons.buttons.len(), 2, "a Ctrl combination deleted a row");
+        assert_eq!(
+            buttons.buttons[0].label, "A",
+            "a Ctrl combination reordered"
+        );
+
+        let mut add = Modal::AddRepository(AddRepositoryModal::new());
+        for event in typed("/tmp/repo") {
+            add.handle_key(event);
+        }
+        add.handle_key(ctrl(KeyCode::Char('u')));
+        let Modal::AddRepository(add) = &add else {
+            unreachable!("the modal was replaced");
+        };
+        assert_eq!(add.path.value(), "", "Ctrl+U no longer reaches the field");
     }
 
     #[test]

--- a/src/services/tmux.rs
+++ b/src/services/tmux.rs
@@ -118,12 +118,90 @@ pub fn rename_window(name: &str) -> bool {
     tmux(&["rename-window", "-t", &window, name]).is_some()
 }
 
+/// What `ensure_focus_events` found, and therefore what exit has to undo.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FocusEvents {
+    /// Not inside tmux, or tmux refused the option.
+    Unavailable,
+    /// Someone else's setting — leave it exactly as it is.
+    AlreadyOn,
+    /// Ours to undo, either because we just turned it on or because a previous
+    /// forestui did and died before it could.
+    Ours,
+}
+
+/// Marks `focus-events` as forestui's doing, so the option can be handed back
+/// even when the run that set it never reached its cleanup.
+///
+/// Without it, one panic or `SIGTERM` would leave the option on forever: every
+/// later run would find it already on, conclude it was the user's, and refuse
+/// to touch it. A tmux user option is the natural place for the flag — it
+/// lives exactly as long as the server whose setting it describes.
+const FOCUS_EVENTS_MARKER: &str = "@forestui_focus_events";
+
 /// Enable the tmux `focus-events` option so the app can refresh on focus.
-pub fn ensure_focus_events() -> bool {
+///
+/// It is a **server** option: turning it on reaches every session, window and
+/// client on that tmux server, and nothing turns it off again on its own. That
+/// is not free — while it is on, tmux asks the terminal for focus reporting,
+/// and a focus report that arrives between the prefix key and the next key
+/// cancels the tmux command (issue #51). So this reports whether the option is
+/// ours to undo, and [`disable_focus_events`] hands it back.
+pub fn ensure_focus_events() -> FocusEvents {
     if !is_inside_tmux() {
-        return false;
+        return FocusEvents::Unavailable;
     }
-    tmux(&["set-option", "-g", "focus-events", "on"]).is_some()
+
+    if tmux(&["show-options", "-gv", "focus-events"]).is_some_and(|v| v.trim() == "on") {
+        return if marked_as_ours() {
+            FocusEvents::Ours
+        } else {
+            FocusEvents::AlreadyOn
+        };
+    }
+
+    if tmux(&["set-option", "-g", "focus-events", "on"]).is_some() {
+        let _ = tmux(&["set-option", "-g", FOCUS_EVENTS_MARKER, "on"]);
+        FocusEvents::Ours
+    } else {
+        FocusEvents::Unavailable
+    }
+}
+
+/// Put `focus-events` back to off, for the run that owns it.
+///
+/// Only called for [`FocusEvents::Ours`], so a user who set the option
+/// themselves keeps it. Two forestui instances can still disagree — the first
+/// to exit turns it off under the second, which costs that instance its
+/// refresh-on-return until it restarts. That is the cheaper of the two
+/// mistakes: the other one is changing the user's server permanently and never
+/// telling them.
+pub fn disable_focus_events() {
+    if !is_inside_tmux() {
+        return;
+    }
+    let _ = tmux(&["set-option", "-g", "focus-events", "off"]);
+    let _ = tmux(&["set-option", "-gu", FOCUS_EVENTS_MARKER]);
+}
+
+/// Hand back a `focus-events` a previous forestui stranded, for a run that
+/// wants nothing to do with it.
+///
+/// `--no-focus-events` is what someone reaches for when focus reporting is
+/// costing them a tmux prefix, so it has to clear the setting a crashed run
+/// left behind rather than only declining to add one.
+pub fn release_stranded_focus_events() {
+    if is_inside_tmux() && marked_as_ours() {
+        disable_focus_events();
+    }
+}
+
+/// Whether a forestui — this one or one that died before cleaning up — is what
+/// turned `focus-events` on.
+fn marked_as_ours() -> bool {
+    // An unset user option is an error, not an empty value, so a failed call
+    // is the "not ours" answer rather than something to report.
+    tmux(&["show-options", "-gv", FOCUS_EVENTS_MARKER]).is_some_and(|v| v.trim() == "on")
 }
 
 fn window_names() -> Vec<String> {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,481 @@
+//! The terminal input modes forestui turns on, and every way out of the
+//! process that has to turn them off again.
+//!
+//! These modes live in the *terminal*, not in the process, so nothing resets
+//! them when forestui dies without getting to its cleanup: a pane whose
+//! application is gone can be left reporting every pointer movement, on the
+//! alternate screen, in raw mode. Inside tmux that is the pane's own state;
+//! forestui started from a shell prompt hands it straight back to that shell.
+//!
+//! Defect A of issue #51 was that the OFF string lived on exactly one branch
+//! of `run()`. It is now emitted from four places, each covering what the
+//! others cannot:
+//!
+//! 1. [`ModeGuard`]'s `Drop` — normal exit, an early `?`, and any unwinding
+//!    panic.
+//! 2. A chained panic hook — the same panic, but also under `panic = "abort"`,
+//!    where nothing is dropped. `ratatui`'s own hook restores the *screen* and
+//!    knows nothing about these modes, so after a panic the display looked
+//!    perfectly fine while all five modes were still set.
+//! 3. A signal handler — `SIGTERM`/`SIGHUP` from a killed pane or window,
+//!    where neither of the above runs.
+//! 4. The next launch — `SIGKILL` can never be handled, so startup emits OFF
+//!    before ON and heals whatever the previous run left behind.
+//!
+//! None of this explains the terminal wedge issue #51 was opened for: that
+//! happens while forestui is *running*, so nothing has exited and nothing has
+//! leaked. This module fixes the defect, not that.
+
+use std::io::Write;
+
+/// Every mode forestui can ask for: mouse buttons, drag, any-motion, SGR
+/// coordinates, focus. [`modes_on`] narrows it to what a given run wants.
+///
+/// `?1003h` (any-motion) is what makes hover possible at all: without it the
+/// terminal never reports a bare move, so no control can light up under the
+/// pointer. It was previously left off because every motion report woke the
+/// loop and repainted, which read as the app flickering under a moving mouse.
+/// That is fixed at the source instead — `App::handle_mouse` only marks the
+/// frame dirty when the *hovered target changes*, so crossing a control costs
+/// one repaint and sliding around inside it costs none.
+///
+/// `?1006h` asks for SGR coordinates so columns past 223 still resolve.
+///
+/// `?1004h` asks for focus reporting, and without it the terminal never sends
+/// focus in/out at all — so `Event::FocusGained` never arrived and everything
+/// hung off it was dead code. `ensure_focus_events` turning on tmux's
+/// `focus-events` is only half of the handshake: tmux forwards the sequences
+/// to a pane that asked for them, and this is the asking.
+///
+/// Kept as one string so a test can pin it: a mode dropped from here fails
+/// silently and takes a whole feature with it, which is how focus reporting
+/// went missing and left `Event::FocusGained` unable to fire at all. A test
+/// also pins the reverse — every mode set here has a matching reset in
+/// [`MODES_OFF`], because a mode with no way off is the defect this module
+/// exists for.
+pub const MODES_ON: &str = "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1004h";
+
+/// The same modes, unset, in reverse order.
+///
+/// Always the *whole* set, whatever [`InputModes`] asked for: it doubles as
+/// the self-heal, and a run that left a mode on is exactly the run whose flags
+/// we cannot know.
+pub const MODES_OFF: &str = "\x1b[?1004l\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+
+/// The two modes that are optional, because each one costs something inside
+/// tmux beyond the feature it buys.
+///
+/// A mouse or focus report that reaches tmux between the prefix key and the
+/// next key cancels the command — tmux looks the report up in the `prefix`
+/// key table, finds nothing, and falls back to the root table. That is
+/// ordinary tmux behaviour with `mouse on`, but these two modes widen what
+/// counts as a report: `?1003h` makes a bare pointer *move* one, and
+/// `?1004h` (with tmux's `focus-events`) makes every focus change one. Neither
+/// is bindable in tmux 3.4, so a user who trips over it has no config-side
+/// defence — hence the flags (issue #51).
+const MOTION_ON: &str = "\x1b[?1003h";
+const FOCUS_ON: &str = "\x1b[?1004h";
+
+/// Which optional input modes this run asks for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InputModes {
+    /// `?1003h`: any-motion reporting, which is what hover highlighting needs.
+    pub hover: bool,
+    /// `?1004h` plus tmux's `focus-events`: refreshing when the user returns.
+    pub focus: bool,
+}
+
+impl Default for InputModes {
+    fn default() -> Self {
+        Self {
+            hover: true,
+            focus: true,
+        }
+    }
+}
+
+/// [`MODES_ON`] with the modes this run declined removed.
+pub fn modes_on(modes: InputModes) -> String {
+    let mut sequence = MODES_ON.to_string();
+    if !modes.hover {
+        sequence = sequence.replace(MOTION_ON, "");
+    }
+    if !modes.focus {
+        sequence = sequence.replace(FOCUS_ON, "");
+    }
+    sequence
+}
+
+/// What a launch writes before it draws anything: OFF, then ON.
+///
+/// The leading OFF is the self-heal. `SIGKILL`, a pulled power cord and a
+/// crashed terminal emulator can all leave the modes set with no chance to
+/// clean up, and this makes that state cost one launch instead of being sticky
+/// until the user finds the magic `printf`. It is also what makes the flags
+/// honest: a run started with `--no-hover` turns motion reporting *off* even
+/// if the previous run left it on.
+pub fn startup_sequence(modes: InputModes) -> String {
+    format!("{MODES_OFF}{}", modes_on(modes))
+}
+
+/// Owns the input modes for as long as it is alive.
+///
+/// Generic over the sink purely so a test can watch what it emits; the app
+/// hands it `std::io::stdout()`.
+pub struct ModeGuard<W: Write> {
+    out: W,
+}
+
+impl<W: Write> ModeGuard<W> {
+    /// The return value *is* the feature: dropping it turns the modes off, so
+    /// a call whose guard is not held for the life of the UI turns them
+    /// straight back off again.
+    #[must_use]
+    pub fn enable(mut out: W, modes: InputModes) -> Self {
+        let _ = out.write_all(startup_sequence(modes).as_bytes());
+        let _ = out.flush();
+        Self { out }
+    }
+}
+
+impl<W: Write> Drop for ModeGuard<W> {
+    fn drop(&mut self) {
+        let _ = self.out.write_all(MODES_OFF.as_bytes());
+        let _ = self.out.flush();
+    }
+}
+
+/// Emit OFF on a panic, then run whatever hook was already installed.
+///
+/// Call this *after* `ratatui::init()`, so this hook runs first and the modes
+/// are reset before the screen is restored. Chaining rather than replacing is
+/// the point: `ratatui`'s hook is what leaves the alternate screen and takes
+/// the terminal out of raw mode, and dropping it would trade one silent
+/// breakage for another.
+pub fn chain_panic_hook() {
+    install_panic_hook(|| {
+        let mut out = std::io::stdout();
+        let _ = out.write_all(MODES_OFF.as_bytes());
+        let _ = out.flush();
+    });
+}
+
+fn install_panic_hook(emit: fn()) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        emit();
+        previous(info);
+    }));
+}
+
+/// Reset the terminal from a signal handler, then die of the signal.
+///
+/// Must be installed before `ratatui::init()` enables raw mode: it snapshots
+/// the terminal settings it finds, and those are the ones it puts back.
+#[cfg(unix)]
+pub fn install_signal_handlers() {
+    signals::install();
+}
+
+#[cfg(not(unix))]
+pub fn install_signal_handlers() {}
+
+#[cfg(unix)]
+mod signals {
+    use std::cell::UnsafeCell;
+    use std::mem::MaybeUninit;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// The terminal settings from before raw mode, for the handler to restore.
+    ///
+    /// A plain `static` because a signal handler cannot take a lock: it may
+    /// run on any thread, at any instruction, including one inside that same
+    /// lock. Only `install` writes it, once, before any handler exists.
+    struct SavedTermios(UnsafeCell<MaybeUninit<libc::termios>>);
+
+    // SAFETY: written once by `install` before the first handler is armed and
+    // only read afterwards.
+    unsafe impl Sync for SavedTermios {}
+
+    /// Leave the alternate screen and show the cursor.
+    ///
+    /// `ratatui::restore()` does this on every path that unwinds; nothing does
+    /// it when a signal kills us mid-frame, and forestui started from a shell
+    /// prompt inside a tmux window leaves that shell behind — on the alternate
+    /// screen, with no cursor, in raw mode. Only the handler needs it, which is
+    /// why it is not part of `MODES_OFF`.
+    const SCREEN_RESTORE: &str = "\x1b[?1049l\x1b[?25h";
+
+    static SAVED: SavedTermios = SavedTermios(UnsafeCell::new(MaybeUninit::uninit()));
+    static HAVE_SAVED: AtomicBool = AtomicBool::new(false);
+
+    /// The signals that end forestui in practice: a killed pane or window, a
+    /// closed terminal, a `kill` from a shell, an `abort()`.
+    ///
+    /// `SIGKILL` and `SIGSTOP` are absent because they cannot be caught, which
+    /// is what the self-heal on the next launch is for. `SIGSEGV` and `SIGBUS`
+    /// are absent deliberately: Rust installs its own handler for those on an
+    /// *alternate stack*, which is what prints "has overflowed its stack".
+    /// Replacing it would trade that diagnostic for nothing — a handler
+    /// without an alternate stack cannot run on an overflowed one anyway.
+    const FATAL: [libc::c_int; 5] = [
+        libc::SIGHUP,
+        libc::SIGINT,
+        libc::SIGQUIT,
+        libc::SIGTERM,
+        libc::SIGABRT,
+    ];
+
+    pub fn install() {
+        // SAFETY: a plain `tcgetattr` into local storage; failure (not a tty)
+        // leaves `HAVE_SAVED` false and the handler simply skips the restore.
+        unsafe {
+            let mut current = MaybeUninit::<libc::termios>::uninit();
+            if libc::tcgetattr(libc::STDIN_FILENO, current.as_mut_ptr()) == 0 {
+                *SAVED.0.get() = current;
+                HAVE_SAVED.store(true, Ordering::SeqCst);
+            }
+        }
+
+        for signal in FATAL {
+            // SAFETY: `action` is fully initialised below and the handler is a
+            // valid `extern "C"` function for the lifetime of the process.
+            unsafe {
+                let mut action: libc::sigaction = std::mem::zeroed();
+                action.sa_sigaction = handle_fatal as *const () as libc::sighandler_t;
+                libc::sigemptyset(&mut action.sa_mask);
+                // SA_RESETHAND puts the default disposition back on entry, so
+                // the `raise` below kills the process with the signal it was
+                // sent — the exit status stays honest and a SIGSEGV still
+                // dumps core.
+                action.sa_flags = libc::SA_RESETHAND;
+                libc::sigaction(signal, &action, std::ptr::null_mut());
+            }
+        }
+    }
+
+    /// Async-signal-safe by construction: `write`, `tcsetattr` and `raise` are
+    /// all on the POSIX list, and nothing here allocates or locks.
+    extern "C" fn handle_fatal(signal: libc::c_int) {
+        write_all(super::MODES_OFF.as_bytes());
+        write_all(SCREEN_RESTORE.as_bytes());
+
+        if HAVE_SAVED.load(Ordering::SeqCst) {
+            // SAFETY: `SAVED` was initialised before this handler was armed.
+            unsafe {
+                libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, (*SAVED.0.get()).as_ptr());
+            }
+        }
+
+        // SAFETY: re-raising with the default disposition restored above.
+        unsafe {
+            libc::raise(signal);
+        }
+    }
+
+    /// `write(2)` straight at the file descriptor, looping over short writes.
+    /// `print!` would take the stdout lock, which is exactly what a handler
+    /// must not do.
+    fn write_all(mut bytes: &[u8]) {
+        while !bytes.is_empty() {
+            // SAFETY: writing `bytes.len()` bytes from a slice we hold.
+            let written = unsafe {
+                libc::write(
+                    libc::STDOUT_FILENO,
+                    bytes.as_ptr().cast(),
+                    bytes.len() as libc::size_t,
+                )
+            };
+            if written <= 0 {
+                // EINTR is the only error worth retrying, and a handler that
+                // spins on a closed terminal is worse than a missed reset.
+                return;
+            }
+            bytes = &bytes[written as usize..];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// A sink the test can still read after the guard that owns it is dropped.
+    #[derive(Clone, Default)]
+    struct Recorder(Arc<Mutex<Vec<u8>>>);
+
+    impl Recorder {
+        fn written(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap_or_else(|e| e.into_inner())).into_owned()
+        }
+    }
+
+    impl Write for Recorder {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Both of these are load-bearing and neither fails loudly.
+    ///
+    /// Without `?1003h` the terminal never reports a bare pointer move, so
+    /// hover cannot work. Without `?1004h` it never reports focus at all, so
+    /// `Event::FocusGained` never arrives and everything hanging off it —
+    /// refreshing sessions and worktrees when the user comes back — is dead
+    /// code that still compiles and still has passing tests.
+    #[test]
+    fn the_terminal_modes_we_depend_on_are_requested() {
+        for (mode, why) in [
+            ("?1003h", "any-motion, for hover"),
+            ("?1004h", "focus reporting, for refresh on return"),
+            ("?1006h", "SGR coordinates, for columns past 223"),
+        ] {
+            assert!(MODES_ON.contains(mode), "{mode} ({why}) is not requested");
+            let off = mode.replace('h', "l");
+            assert!(
+                MODES_OFF.contains(&off),
+                "{mode} ({why}) is requested but never turned off"
+            );
+        }
+    }
+
+    /// The general form of the above: a mode added to ON with no counterpart
+    /// in OFF is a new leak, whatever it is called.
+    #[test]
+    fn every_mode_we_turn_on_has_a_way_off() {
+        let modes: Vec<&str> = MODES_ON
+            .split("\x1b[")
+            .filter(|part| !part.is_empty())
+            .collect();
+        assert_eq!(modes.len(), 5, "MODES_ON no longer parses as we expect");
+
+        for mode in modes {
+            let off = mode.replace('h', "l");
+            assert!(
+                MODES_OFF.contains(&off),
+                "\x1b[{mode} is set but \x1b[{off} is never sent"
+            );
+        }
+    }
+
+    /// The self-heal. A terminal a `SIGKILL`ed run left stranded is fixed by
+    /// the next launch, so the bug costs one restart rather than a printf the
+    /// user has to be told about.
+    #[test]
+    fn startup_turns_the_modes_off_before_turning_them_on() {
+        let sequence = startup_sequence(InputModes::default());
+        let off = sequence.find(MODES_OFF).expect("startup must reset first");
+        let on = sequence.find(MODES_ON).expect("startup must set the modes");
+        assert!(off < on, "startup set the modes before resetting them");
+    }
+
+    /// Declining a mode drops that request and nothing else — and never
+    /// narrows the reset, which has to cover whatever a previous run set.
+    #[test]
+    fn declining_a_mode_drops_only_that_request() {
+        let without_hover = modes_on(InputModes {
+            hover: false,
+            ..InputModes::default()
+        });
+        assert!(
+            !without_hover.contains("?1003h"),
+            "hover survived --no-hover"
+        );
+        for kept in ["?1000h", "?1002h", "?1006h", "?1004h"] {
+            assert!(
+                without_hover.contains(kept),
+                "--no-hover also dropped {kept}"
+            );
+        }
+
+        let without_focus = modes_on(InputModes {
+            focus: false,
+            ..InputModes::default()
+        });
+        assert!(
+            !without_focus.contains("?1004h"),
+            "focus survived --no-focus-events"
+        );
+        assert!(
+            without_focus.contains("?1003h"),
+            "--no-focus-events took hover"
+        );
+
+        let neither = modes_on(InputModes {
+            hover: false,
+            focus: false,
+        });
+        assert_eq!(neither, "\x1b[?1000h\x1b[?1002h\x1b[?1006h");
+        assert!(
+            startup_sequence(InputModes {
+                hover: false,
+                focus: false,
+            })
+            .starts_with(MODES_OFF),
+            "a narrowed run must still reset every mode first"
+        );
+    }
+
+    #[test]
+    fn dropping_the_guard_turns_the_modes_off() {
+        let recorder = Recorder::default();
+        drop(ModeGuard::enable(recorder.clone(), InputModes::default()));
+
+        let written = recorder.written();
+        assert!(written.ends_with(MODES_OFF), "the guard left the modes on");
+    }
+
+    /// The path `ratatui`'s panic hook leaves uncovered: the screen is
+    /// restored, and without this the modes are not.
+    #[test]
+    fn the_guard_turns_the_modes_off_when_the_frame_unwinds() {
+        let recorder = Recorder::default();
+        let held = recorder.clone();
+        let result = std::panic::catch_unwind(move || {
+            let _guard = ModeGuard::enable(held, InputModes::default());
+            panic!("the event loop fell over");
+        });
+
+        assert!(result.is_err(), "the panic did not propagate");
+        assert!(
+            recorder.written().ends_with(MODES_OFF),
+            "an unwinding panic left the modes on"
+        );
+    }
+
+    /// `Drop` does not run under `panic = "abort"`, so the hook has to emit the
+    /// reset itself — and still hand over to `ratatui`'s hook, which is what
+    /// leaves the alternate screen.
+    ///
+    /// This swaps the process-wide panic hook for the length of the test. No
+    /// other test panics deliberately, so the only thing it can swallow is the
+    /// message from a test that is already failing.
+    #[test]
+    fn the_panic_hook_resets_the_modes_and_still_runs_the_previous_hook() {
+        static RESET: AtomicBool = AtomicBool::new(false);
+        static PREVIOUS_RAN: AtomicBool = AtomicBool::new(false);
+
+        let original = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| PREVIOUS_RAN.store(true, Ordering::SeqCst)));
+        install_panic_hook(|| RESET.store(true, Ordering::SeqCst));
+
+        let _ = std::panic::catch_unwind(|| panic!("boom"));
+        std::panic::set_hook(original);
+
+        assert!(RESET.load(Ordering::SeqCst), "the hook left the modes on");
+        assert!(
+            PREVIOUS_RAN.load(Ordering::SeqCst),
+            "the hook swallowed ratatui's screen restore"
+        );
+    }
+}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -8,6 +8,30 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
+/// Whether a key press is the bare character, and so may fire a letter
+/// shortcut.
+///
+/// `Ctrl` and `Alt` combinations belong to the terminal and to tmux; forestui
+/// binding them by accident is how `Ctrl+A` opened Add Repository and `Ctrl+D`
+/// deleted a worktree, because every shortcut in the app matches on
+/// `KeyCode::Char` alone (Defect B of issue #51). A prefix of `C-a` with
+/// `bind C-a send-prefix` puts a literal `Ctrl+A` into the pane by design, so
+/// the app *will* be handed these keys and must decline them. `Shift` is
+/// allowed — `A` (Archived) is a binding.
+pub fn is_plain_press(key: KeyEvent) -> bool {
+    key.modifiers.difference(KeyModifiers::SHIFT).is_empty()
+}
+
+/// Whether a modifier-carrying key is one [`TextInput`] itself acts on.
+///
+/// The exception list for the rule above: a focused field has to keep its
+/// `Ctrl+U`, so the shortcut guards ask here before dropping a modified key.
+/// Both sides read this one function, so adding an editing combination cannot
+/// leave it filtered out before the field ever sees it.
+pub fn text_input_claims(key: KeyEvent) -> bool {
+    key.code == KeyCode::Char('u') && key.modifiers.contains(KeyModifiers::CONTROL)
+}
+
 /// A single-line text field with a cursor.
 ///
 /// Hand-rolled rather than pulled from a crate: the app needs exactly insert,
@@ -121,11 +145,18 @@ impl TextInput {
     /// silently miss the other. Callers layer their own Enter/Escape handling.
     pub fn apply_edit_key(&mut self, key: KeyEvent) -> bool {
         match key.code {
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.kill_to_start();
-                true
+            // A modified character is either an editing combination or not
+            // ours at all — inserting it would have typed the letter out of
+            // `Alt+d` into the field.
+            KeyCode::Char(_) if !is_plain_press(key) => {
+                if text_input_claims(key) {
+                    self.kill_to_start();
+                    true
+                } else {
+                    false
+                }
             }
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c) => {
                 self.insert(c);
                 true
             }
@@ -334,6 +365,32 @@ mod tests {
         input.move_home();
         input.delete();
         assert_eq!(input.value(), "bc");
+    }
+
+    /// A modified character is not text: `Alt+d` used to type a `d` into the
+    /// field, and every other `Ctrl` combination fell through to a letter
+    /// shortcut (Defect B of issue #51). `Ctrl+U` is the one the editor claims.
+    #[test]
+    fn only_the_editors_own_combination_survives_a_modifier() {
+        use ratatui::crossterm::event::{KeyEventKind, KeyEventState};
+
+        let modified = |code, modifiers| KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        };
+
+        let mut input = TextInput::new("hello");
+        assert!(!input.apply_edit_key(modified(KeyCode::Char('d'), KeyModifiers::ALT)));
+        assert!(!input.apply_edit_key(modified(KeyCode::Char('a'), KeyModifiers::CONTROL)));
+        assert_eq!(input.value(), "hello", "a modified key was typed as text");
+
+        assert!(input.apply_edit_key(modified(KeyCode::Char('!'), KeyModifiers::SHIFT)));
+        assert_eq!(input.value(), "hello!", "Shift is part of typing");
+
+        assert!(input.apply_edit_key(modified(KeyCode::Char('u'), KeyModifiers::CONTROL)));
+        assert_eq!(input.value(), "", "Ctrl+U no longer clears the field");
     }
 
     #[test]


### PR DESCRIPTION
Fixes the two confirmed defects in #51. The wedge investigation in that issue stays open — see the last section.

## Defect A — `TERMINAL_MODES_OFF` was reachable from one code path

forestui asks the terminal for five DEC private modes at startup and turned them off only on the normal exit of the main loop. A panic, a `SIGTERM` from a killed pane or window, or a `SIGKILL` left all five set. The nastiest part was the panic: ratatui's own hook restores the *screen* and knows nothing about these modes, so the display looked perfectly clean while mouse reporting stayed live.

`src/terminal.rs` now owns the modes and emits the reset from four places, each covering what the others cannot:

1. **A guard's `Drop`** — normal exit, an early `?`, any unwinding panic.
2. **A chained panic hook** — the same panic, but also under `panic = "abort"`, where nothing is dropped. It runs ahead of ratatui's hook rather than replacing it. (`Cargo.toml` sets no panic strategy, so release unwinds; the hook is there for the case where that changes.)
3. **A signal handler** — `SIGHUP`/`SIGINT`/`SIGQUIT`/`SIGTERM`/`SIGABRT`, using only async-signal-safe calls. It also puts termios back and leaves the alternate screen, so a shell that launched forestui comes back usable rather than echo-less on the alt screen, and it re-raises with the default disposition so the exit status stays honest. `SIGSEGV`/`SIGBUS` are deliberately *not* taken: Rust's own handler for those runs on an alternate stack and is what prints "has overflowed its stack".
4. **The next launch** — `SIGKILL` can never be handled, so startup emits OFF before ON.

## Defect B — `Ctrl`+letter fired plain-letter bindings

The key handler matched `KeyCode::Char` alone, so any `Ctrl`+letter ran the plain binding. With `bind C-a send-prefix`, a literal `Ctrl+A` that tmux hands to the pane opened Add Repository, and `Ctrl+D` started deleting a worktree. Footer bindings and the modals' letter shortcuts now require an unmodified press (`Shift` allowed, since `A` is a binding). `Ctrl+C` still quits, the text editor keeps `Ctrl+U`, and footer clicks through `mouse.rs` are unaffected.

## Two related fixes to state forestui left behind

- tmux's `focus-events` is a **server** option. forestui turned it on and never off, so every window on that server kept reporting focus changes long after forestui exited. It is handed back on exit, and ownership is recorded in a tmux user option rather than in memory — a run killed before its cleanup no longer strands it forever, since the next run adopts and returns it. A setting the user turned on themselves is left alone.
- `--no-hover` and `--no-focus-events` drop `?1003h` and `?1004h`. Defaults are unchanged.

## Verification

`scripts/terminal-modes-probe.py` is new and committed: it runs the built binary on a private pty, kills it every way that used to leak, and asserts what actually reached the terminal. It fails on `main` and passes here.

| | `main` | this branch |
|---|---|---|
| SIGTERM / SIGHUP / SIGINT: modes off | fail | pass |
| …alternate screen left, echo restored | fail | pass |
| panic: modes off (screen looked fine either way) | fail | pass |
| startup resets before setting (SIGKILL self-heal) | fail | pass |
| exit status still reports the signal | pass | pass |
| normal quit | pass | pass |

Also: 228 unit tests, `make check`, `make check-shipped`, and a full `scripts/tu-sweep.sh` — 21/21 assertions, no wait timeouts, all 96 frames byte-identical to the committed baseline. The `focus-events` ownership was exercised end-to-end in an isolated tmux 3.4: off → run → on+marker → quit → off; `SIGKILL` strands it and the next run hands it back; `--no-focus-events` clears a stranded one; a user-owned setting survives untouched.

## What this does not fix

#51 also carries an open investigation into a terminal that stops responding to the tmux prefix *while forestui is running*. Measured in an isolated tmux 3.4 with a probe binding: tmux cancels a pending prefix when the next thing it receives is a key with no binding in the `prefix` table, and a mouse or focus report is such a key. Wheel, click and drag do it with `mouse on` alone — with or without forestui, in any window. `?1003h` adds bare pointer motion to that set while forestui's pane is active, and `focus-events` adds focus changes everywhere; neither has a key name to bind in tmux 3.4, which is what the two flags are for. Defect B is what turned a swallowed prefix into a modal opening. Leaving #51 open for that half.