### PR TITLE
Run Claude as a job of the window's shell, not as the window itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,10 +267,10 @@ window instead.
 - **`@claude_birth_name`**, a tmux window option stamped when the window is
   created, answers one question: did forestui open this window? A window the
   user made by hand carries none and is left alone, as is a bare `claude` in a
-  plain terminal. It is written from *inside* the window, in a prelude ahead of
-  the command that needs it — stamping it from forestui after `new-window`
-  returns is a separate tmux call, and a fast-starting Claude could reach its
-  first hook before it lands.
+  plain terminal. It is written from *inside* the window, ahead of the command
+  that needs it — stamping it from forestui after `new-window` returns is a
+  separate tmux call, and a fast-starting Claude could reach its first hook
+  before it lands.
 - **`@claude_synced_name`** records the last agreed name. Two-way sync cannot
   tell which side moved from one value: equal names are ambiguous between
   nobody changing and both changing alike, and unequal names do not say who is
@@ -278,9 +278,9 @@ window instead.
 - **Window names reach a shell**, so they are quoted literally with single
   quotes rather than by any escaping heuristic. A session title can be set by a
   `SessionStart` hook in a repository's own `.claude/settings.json`, so by the
-  time a name gets here it is not necessarily the user's own text. These
-  commands run through `-ic`, an *interactive* shell, where double quotes would
-  not even stop zsh history expansion.
+  time a name gets here it is not necessarily the user's own text. The shell
+  reading it is *interactive*, where double quotes would not even stop zsh
+  history expansion.
 
 There is deliberately no off switch, per window or global. Installed means the
 two names agree; not wanting that is an uninstall.
@@ -311,6 +311,69 @@ client on that server, and it used to stay on long after forestui exited.
 option rather than in memory, so a run that is killed before its cleanup does
 not strand the setting forever — the next run adopts it and hands it back. A
 user who set the option themselves keeps it, marker absent.
+
+### Claude runs inside a shell, not as the window's command
+
+A tmux window forestui opens for Claude runs the user's shell, interactively,
+and Claude is one of its *jobs* — not the window's own process.
+
+That is the whole point. A window whose only process is Claude has nothing
+underneath it: Ctrl-C leaves a dead pane, and Claude's own Ctrl-Z suspend stops
+the process with no shell left to `fg` it back, so the session is unreachable
+and the window gets closed to be rid of it — a lost conversation. With a shell
+underneath, both land at a prompt: `fg` resumes a suspended session, the up
+arrow restarts an exited one, and nothing has to be thrown away.
+
+The command is **not typed into the window**. It is written into a startup file
+that forestui generates and points the shell at, so it is already there when
+the shell reads it — nothing to race, nothing to arrive half-read. Each shell
+has exactly one such hook, and each hook *replaces* one of the user's own files
+rather than adding to it, so the generated file sources the file it displaced:
+
+| shell | pointed at with | replaces, so sources back |
+|---|---|---|
+| zsh | `ZDOTDIR=<dir>` | `.zshenv` and `.zshrc` |
+| bash | `--rcfile <file>` | `.bashrc` |
+| sh, dash, ksh, mksh, ash, yash | `ENV=<file>` | whatever `ENV` already named |
+
+The shell is started interactive and non-login, which is exactly what
+`$SHELL -ic` gave before, so a Claude window's environment is unchanged from
+the build that ran Claude directly. `startup_for` is pure and tested; the file
+deletes itself once read, so nothing accumulates in the temp dir.
+
+Three things in the generated file are load-bearing:
+
+- **`set -m`.** Without it a command run from a startup file is not a job:
+  bash hands it the shell's own ignored `SIGTSTP`, so Ctrl-Z does nothing at
+  all and the window wedges with no way back. zsh already runs interactive
+  shells this way; saying so costs nothing and makes the file mean the same
+  thing under every shell.
+- **The birth stamp goes in ahead of the command**, from inside the window, for
+  the reason it always did: the shell starts Claude by itself, so a stamp
+  forestui sends after `new-window` returns is a separate tmux call a
+  fast-starting Claude can beat to its first hook.
+- **The command is pushed into the shell's history** (`print -s`, `history -s`)
+  where the shell has a builtin for it. Typing it used to do that for free, and
+  after an accidental Ctrl-C the up arrow is the shortest way back.
+
+A shell with no hook we have tested — fish, nushell — falls back to typing the
+line into a plain shell with `send-keys`. That path is a real fallback, not a
+leftover: it needs no per-shell knowledge at all. Its one weakness is why it is
+not the default — keystrokes sent before the shell is ready wait in the
+terminal for it, and a startup that *consumes* input (zsh-newuser-install in a
+bare `HOME` is a real example) eats them. Because it is keystrokes, the line
+must be one line of text: `send-keys -l` sends literal characters and `Enter`
+is a separate key name, which is why it is two calls.
+
+Either way the line itself is built by `claude_command_line` and stripped of
+control characters by `single_line`. A newline in a window name would be an
+Enter key on one path and a second line of the startup file on the other — and
+window names come from session titles, which a repository's own
+`.claude/settings.json` can set.
+
+The cost of all this is that the window no longer closes when Claude exits; it
+drops to a prompt, like any other terminal. That is the trade, and it is the
+right way round.
 
 ### Self-update
 forestui keeps itself current the way the Python build did — automatically, on

--- a/doc/rust-rewrite/ARCHITECTURE.md
+++ b/doc/rust-rewrite/ARCHITECTURE.md
@@ -658,9 +658,12 @@ build) asserting `serde_json::Value` equality after a round trip is the check th
   terminal/files/claude windows are *always new*. Snapshot-test this — the project's own testing
   note calls out "wrong window names" as a real regression class.
 - **Claude command construction.** `$SHELL -ic <quoted cmd>` (`tmux.py:352`) so shell aliases work,
-  with `shlex.quote` on the command. Rust equivalent: pass the command as a single argv element to
-  `-c`, and quote with a `shell_quote` helper — do **not** build one big string and let a shell
-  re-split it.
+  with `shlex.quote` on the command. The Rust build keeps the quoting and drops the wrapper: the
+  window runs the same interactive, non-login shell, but reads the command from a startup file
+  forestui generates for it (`ZDOTDIR` / `--rcfile` / `ENV`), under `set -m`. Aliases still
+  resolve and Claude is a job the shell can be handed back from. A window whose own process is
+  Claude has nothing underneath it — Ctrl-C leaves a dead pane and Claude's Ctrl-Z suspend strands
+  the session with no shell to `fg` it.
 - **YOLO flag suppression for custom buttons.** `--dangerously-skip-permissions` is appended only
   for the built-in YOLO button, never for a custom one (`tmux.py:345`), even though a custom command
   may contain the flag itself (which is what turns the button red).

--- a/doc/rust-rewrite/MIGRATION.md
+++ b/doc/rust-rewrite/MIGRATION.md
@@ -267,7 +267,7 @@ modules are stubs totalling 18 lines.
 | Window names `edit:` `term:` `files:` `claude:` `yolo:` `<custom prefix>:` + `repo[:worktree]` | Identical | `src/services/tmux.rs:185-277`, `src/state.rs:165-177`, tested at `src/services/tmux.rs:298-306` and `src/state.rs:232-242` |
 | `:2`, `:3` uniquifying, counter starts at 2 | Identical | `src/services/tmux.rs:151-168`, tested at `:292-296` |
 | `edit:` reuses an existing window; the others always create | Identical | `src/services/tmux.rs:191-194` vs `:202`, `:211`, `:261` |
-| `$SHELL -ic <quoted cmd>` for Claude | Identical | `src/services/tmux.rs:219-238`, tested at `:309-327` |
+| `$SHELL -ic <quoted cmd>` for Claude | **Diverges**: same interactive, non-login startup, but the command reaches the shell through a generated startup file (`ZDOTDIR` / `--rcfile` / `ENV`) and runs under `set -m`, so Claude is a job with a shell behind it — Ctrl-C and Claude's own Ctrl-Z suspend land at a prompt instead of killing the window or stranding the session | `src/services/tmux.rs`, `startup_for` / `create_claude_window` |
 | `--dangerously-skip-permissions` only for the built-in YOLO button | Identical | `src/services/tmux.rs:227-229` ↔ `tmux.py:345` |
 | `-r <session_id>` appended on resume | Identical | `src/services/tmux.rs:231-233` |
 | Target session = most recently active client in our session group, with both fallbacks | Identical | `src/services/tmux.rs:35-91` ↔ `tmux.py:56-107` — the behaviour UC-40 pins |

--- a/doc/rust-rewrite/TU_USECASES.md
+++ b/doc/rust-rewrite/TU_USECASES.md
@@ -597,11 +597,16 @@ not selected.
 1. `tu press --name fui Ctrl+B 0`; `sleep 1`; `tu press --name fui n`; `sleep 3`; `tu screenshot --name fui`
 2. `tu press --name fui Ctrl+B 0`; `sleep 1`; `tu press --name fui y`; `sleep 3`; `tu screenshot --name fui`
 
-**Expected:** windows `2:claude:alpha:wt-two*` and `3:yolo:alpha:wt-two*`. The
-command is run through an **interactive login shell** (`$SHELL -ic 'claude'`) so
-shell aliases resolve; the YOLO variant appends `--dangerously-skip-permissions`.
+**Expected:** windows `2:claude:alpha:wt-two*` and `3:yolo:alpha:wt-two*`. Each
+window runs an **interactive shell** that reads the command from a startup file
+forestui generated for it, so shell aliases resolve and Claude is a job the
+shell can be handed back from; the YOLO variant appends
+`--dangerously-skip-permissions`.
 **Fails if:** the prefixes are wrong; the YOLO flag is added to non-YOLO windows or
-missing from YOLO ones; the command bypasses the interactive shell (aliases break).
+missing from YOLO ones; the command bypasses the interactive shell (aliases break);
+or the window's own process is Claude, with no shell to return to when it stops
+(the Python build's `$SHELL -ic 'claude'`, whose window died on Ctrl-C and left a
+suspended session unreachable on Ctrl-Z).
 
 ---
 

--- a/doc/rust-rewrite/baseline/rust/ASSERTIONS.txt
+++ b/doc/rust-rewrite/baseline/rust/ASSERTIONS.txt
@@ -5,6 +5,7 @@ PASS UC-90     mouse-enabled                                  expected=on       
 PASS UC-90     any-motion-for-hover                           expected=yes                          actual=yes
 PASS UC-97     claude-stub-ran                                expected=yes                          actual=yes
 PASS UC-97     window-stamped-with-its-name                   expected=claude:alpha:wt-a            actual=claude:alpha:wt-a
+PASS UC-98     shell-outlives-claude                          expected=yes                          actual=yes
 PASS UC-78     wt-name                                        expected=wt-a-renamed                 actual=wt-a-renamed
 PASS UC-78     wt-dir-exists                                  expected=yes                          actual=yes
 PASS UC-78     old-dir-gone                                   expected=yes                          actual=yes

--- a/scripts/tu-sweep.sh
+++ b/scripts/tu-sweep.sh
@@ -21,16 +21,17 @@
 # vim/mc/claude so the window-creating hotkeys produce windows that stay alive
 # long enough to be named. It never touches the caller's ~/forest or tmux.
 #
-# SHELL is pinned rather than inherited. forestui opens its windows with
-# `$SHELL -ic <command>`, and the fixture HOME is empty — so on a machine whose
-# shell is zsh, every one of those windows was taken over by zsh-newuser-install
-# ("you have no zsh startup files") and the command never ran. The windows still
-# existed and were still named, so every frame assertion passed while the stubs
-# had never once been executed.
+# SHELL is pinned rather than inherited, because it decides both what tmux runs
+# in every window forestui opens and which startup-file hook a Claude window is
+# launched through — and the fixture HOME is empty. On a machine whose shell is
+# zsh, each of those windows was taken over by zsh-newuser-install ("you have
+# no zsh startup files") and the command never ran. The windows still existed
+# and were still named, so every frame assertion passed while the stubs had
+# never once been executed.
 #
-# /bin/sh specifically, because it reads no startup files for a non-login
-# interactive shell: bash would pull in the system-wide /etc/bash.bashrc, whose
-# banner differs per distribution and would land in committed frames.
+# /bin/sh specifically, because it reads next to no startup files and its
+# prompt is a bare `$`: bash would pull in the system-wide /etc/bash.bashrc,
+# whose banner differs per distribution and would land in committed frames.
 
 set -uo pipefail
 
@@ -367,6 +368,26 @@ done
 birth_line="$(head -1 "$ROOT/birth.txt" 2>/dev/null)"
 assert UC-97 claude-stub-ran "yes" "$([ -n "$birth_line" ] && echo yes || echo no)"
 assert UC-97 window-stamped-with-its-name "${birth_line%%	*}" "${birth_line##*	}"
+
+# UC-98: the window outlives Claude. Claude is a job of the window's own shell
+# rather than the window's command, and that is what keeps Ctrl-C — or Claude's
+# own Ctrl-Z suspend, which no stub can imitate — from leaving a pane with
+# nothing left in it to type at. Going back to a window whose command *is*
+# Claude renders frames identical to these, so the proof has to be a shell
+# answering a question after the command in front of it is gone.
+#
+# SHELL is /bin/sh here, so this drives the POSIX `ENV` hook specifically. The
+# zsh and bash hooks are covered by unit tests on the generated files and were
+# driven by hand; a sweep can only ever exercise the shell it pins.
+#
+# The stub UC-64 started is still in the foreground of the window it opened.
+press Ctrl+C; sleep 1.0
+type_ 'echo alive-$((6*7))'; press Enter
+await 'alive-42'
+alive="$(tu screenshot --name "$SESS" 2>/dev/null | python3 -c '
+import json, sys
+print("yes" if "alive-42" in json.load(sys.stdin)["content"] else "no")')"
+assert UC-98 shell-outlives-claude "yes" "$alive"
 
 # Editor reuses its window; terminal always opens a new, uniquified one.
 focus_app; press e

--- a/src/services/tmux.rs
+++ b/src/services/tmux.rs
@@ -3,6 +3,7 @@
 //! Every call shells out to the `tmux` binary. The commands are short-lived and
 //! synchronous — the same blocking behaviour the libtmux-based build had.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub const TUI_EDITORS: [&str; 10] = [
@@ -333,29 +334,44 @@ pub fn create_mc_window(name: &str, path: &str) -> bool {
     new_window(&window_name, path, Some("mc")).is_some()
 }
 
-/// Build the shell command used for a Claude window.
-///
-/// Wrapped in an interactive shell so user aliases resolve; the inner command
-/// is quoted to keep custom commands from breaking out.
 /// A string the shell will read back verbatim, whatever is in it.
 ///
 /// Single quotes are the only shell quoting with no escapes inside them: no
-/// `$`, no backtick, and — since these commands run through `-ic`, an
-/// *interactive* shell — no `!` history expansion either, which double quotes
-/// would not stop in zsh. This matters because window names now come from
-/// session titles, and a session title can be set by a `SessionStart` hook in a
-/// repository's own `.claude/settings.json`, so it is not the user's own text
-/// by the time it reaches here.
+/// `$`, no backtick, and — since this is typed into the window's *interactive*
+/// shell — no `!` history expansion either, which double quotes would not stop
+/// in zsh. This matters because window names now come from session titles, and
+/// a session title can be set by a `SessionStart` hook in a repository's own
+/// `.claude/settings.json`, so it is not the user's own text by the time it
+/// reaches here.
 fn sh_quote(text: &str) -> String {
     format!("'{}'", text.replace('\'', "'\\''"))
 }
 
-pub fn claude_shell_command(
+/// Everything that is not text, removed.
+///
+/// The line ends up as one line of a file the shell reads, so a control
+/// character in it is not a character: a newline inside a window name would
+/// end the line and leave the rest standing as a command of its own. Names
+/// arrive from session titles, which are not the user's own text, so they are
+/// stripped here as well as by the hook that adopts them.
+fn single_line(text: &str) -> String {
+    text.chars().filter(|c| !c.is_control()).collect()
+}
+
+/// The command line a Claude window runs.
+///
+/// It runs as a job of the window's own interactive shell rather than as the
+/// window's command, and that is the point. A window whose only process is
+/// Claude has nothing underneath it: Ctrl-C leaves a dead pane, and Claude's
+/// own Ctrl-Z suspend stops the process with no shell left to `fg` it back —
+/// the session is unreachable and the window is closed to be rid of it.
+/// Running Claude as a job makes both land at a prompt, where `fg` resumes and
+/// the up arrow restarts.
+pub fn claude_command_line(
     resume_session_id: Option<&str>,
     yolo: bool,
     custom_command: Option<&str>,
     custom_prefix: Option<&str>,
-    shell: &str,
     window_name: &str,
 ) -> String {
     let mut cmd = custom_command.unwrap_or("claude").to_string();
@@ -376,17 +392,176 @@ pub fn claude_shell_command(
         // but never drawn.
         cmd.push_str(&format!(" -n {}", sh_quote(window_name)));
     }
-    // The birth stamp is written from inside the window, before the command
-    // that needs it runs. Stamping from forestui after new-window returns is a
-    // separate tmux call, so a fast-starting Claude could reach its first hook
-    // first and be read as a window forestui never opened. Ordering it here
-    // makes that impossible rather than merely unlikely; a failure to stamp
-    // still falls through to the command.
-    let cmd = format!(
-        "tmux set-option -w @claude_birth_name {}; {cmd}",
+    single_line(&cmd)
+}
+
+/// The tail every generated startup file ends with.
+///
+/// `set -m` is the load-bearing line. Without it a command run from a startup
+/// file is not a job: bash hands it the shell's own ignored `SIGTSTP`, so
+/// Ctrl-Z does nothing at all and — because the shell is not waiting for a
+/// stoppable child either — the window wedges with no way back. With it, the
+/// command is a job in its own process group, which is what makes Ctrl-Z leave
+/// a stopped job and a prompt, and `fg` bring it back. zsh already runs
+/// interactive shells this way; saying so costs nothing and makes the file
+/// mean the same thing everywhere.
+///
+/// The birth stamp is written here, from inside the window, for the reason it
+/// always was: the shell starts Claude on its own, so a stamp forestui sends
+/// after `new-window` returns is a separate tmux call that a fast-starting
+/// Claude can beat to its first hook.
+fn startup_tail(window_name: &str, line: &str) -> String {
+    format!(
+        "tmux set-option -w @claude_birth_name {} >/dev/null 2>&1\nset -m\n{line}\n",
         sh_quote(window_name)
-    );
-    format!("{shell} -ic {}", sh_quote(&cmd))
+    )
+}
+
+/// The user's own startup files, as the generated ones have to name them.
+struct ShellHome {
+    home: String,
+    zdotdir: Option<String>,
+    env_file: Option<String>,
+}
+
+impl ShellHome {
+    fn from_env() -> Self {
+        Self {
+            home: std::env::var("HOME").unwrap_or_default(),
+            zdotdir: std::env::var("ZDOTDIR").ok().filter(|v| !v.is_empty()),
+            env_file: std::env::var("ENV").ok().filter(|v| !v.is_empty()),
+        }
+    }
+}
+
+/// A shell that has been pointed at a startup file forestui wrote.
+struct Startup {
+    /// Files to write before the window is created, in order.
+    files: Vec<(PathBuf, String)>,
+    /// The command tmux runs for the window.
+    command: String,
+}
+
+/// Point `shell` at a startup file that runs `line`, or `None` if this shell
+/// has no hook we know.
+///
+/// Every one of these hooks *replaces* one of the user's own files rather than
+/// adding to it — a new `ZDOTDIR` hides `.zshenv` and `.zshrc`, `--rcfile`
+/// stands in for `.bashrc`, `ENV` for whatever `ENV` already named — so each
+/// generated file sources the file it displaced. What the window ends up with
+/// is the environment `$SHELL -ic` used to give it: the same interactive,
+/// non-login startup, with the command running as a job at the end of it.
+///
+/// The generated files delete themselves as soon as the shell has read what it
+/// needs, so a window that is never closed does not leave one behind.
+fn startup_for(
+    shell: &str,
+    dir: &Path,
+    home: &ShellHome,
+    window_name: &str,
+    line: &str,
+) -> Option<Startup> {
+    let base = Path::new(shell).file_name()?.to_str()?;
+    let dir_str = dir.to_str()?;
+    // Typing the command used to put it in the shell's history for free, and
+    // that is worth keeping: after Ctrl-C the up arrow is the shortest way
+    // back into a session. Only the shells with a builtin for it get one.
+    let remembered = match base {
+        "zsh" => format!("print -s -- {}\n", sh_quote(line)),
+        "bash" => format!("history -s {}\n", sh_quote(line)),
+        _ => String::new(),
+    };
+    let tail = format!("{remembered}{}", startup_tail(window_name, line));
+    let tail = tail.as_str();
+    let sweep = format!("rm -rf {}\n", sh_quote(dir_str));
+    let source = |path: String| {
+        let quoted = sh_quote(&path);
+        format!("[ -f {quoted} ] && . {quoted}\n")
+    };
+
+    match base {
+        "zsh" => {
+            // `.zshenv` is read for every shell and `.zshrc` for interactive
+            // ones, so both are hidden by the new ZDOTDIR and both come back
+            // here. ZDOTDIR itself is restored before the user's `.zshrc` runs
+            // — a configuration that keys a cache or a plugin directory off it
+            // must not see forestui's temporary one.
+            let zdot = home.zdotdir.clone().unwrap_or_else(|| home.home.clone());
+            let files = vec![
+                (dir.join(".zshenv"), source(format!("{zdot}/.zshenv"))),
+                (
+                    dir.join(".zshrc"),
+                    format!(
+                        "ZDOTDIR={}\n{sweep}{}{tail}",
+                        sh_quote(&zdot),
+                        source(format!("{zdot}/.zshrc"))
+                    ),
+                ),
+            ];
+            Some(Startup {
+                files,
+                command: format!("env ZDOTDIR={} {} -i", sh_quote(dir_str), sh_quote(shell)),
+            })
+        }
+        "bash" => {
+            let rc = dir.join("rc");
+            let rc_str = rc.to_str()?.to_string();
+            Some(Startup {
+                files: vec![(
+                    rc,
+                    format!("{sweep}{}{tail}", source(format!("{}/.bashrc", home.home))),
+                )],
+                command: format!("{} --rcfile {} -i", sh_quote(shell), sh_quote(&rc_str)),
+            })
+        }
+        // The POSIX interactive startup file, which is whatever `ENV` names.
+        "sh" | "dash" | "ash" | "ksh" | "ksh93" | "mksh" | "loksh" | "yash" => {
+            let rc = dir.join("rc");
+            let rc_str = rc.to_str()?.to_string();
+            let inherited = home.env_file.clone().map(source).unwrap_or_default();
+            Some(Startup {
+                files: vec![(rc, format!("{sweep}{inherited}{tail}"))],
+                command: format!("env ENV={} {} -i", sh_quote(&rc_str), sh_quote(shell)),
+            })
+        }
+        // fish, nushell and friends: no hook here that has been tested, so the
+        // line is typed into a plain shell instead. Nothing is lost but the
+        // typing.
+        _ => None,
+    }
+}
+
+/// Write the startup files for this launch, or `None` to fall back to typing.
+fn prepare_startup(window_name: &str, line: &str) -> Option<Startup> {
+    let shell = std::env::var("SHELL").ok().filter(|s| !s.is_empty())?;
+    let dir = std::env::temp_dir().join(format!(
+        "forestui-launch-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default()
+    ));
+    let startup = startup_for(&shell, &dir, &ShellHome::from_env(), window_name, line)?;
+
+    // A launch that cannot write its files is not an error to show anyone:
+    // typing the line still works, so fall back to it.
+    std::fs::create_dir_all(&dir).ok()?;
+    for (path, contents) in &startup.files {
+        std::fs::write(path, contents).ok()?;
+    }
+    Some(startup)
+}
+
+/// Type a line into a window's shell and run it.
+///
+/// The fallback for a shell with no startup hook of its own. Two calls, because
+/// `-l` sends its arguments as literal characters — the only way to keep a
+/// command line from being read as key names — and `Enter` is precisely a key
+/// name.
+fn send_line(window_id: &str, line: &str) -> bool {
+    tmux(&["send-keys", "-t", window_id, "-l", "--", line]).is_some()
+        && tmux(&["send-keys", "-t", window_id, "Enter"]).is_some()
 }
 
 /// Window name for a Claude session, before uniquifying.
@@ -428,22 +603,36 @@ pub fn create_claude_window(
     current_session()?;
 
     let window_name = find_unique_window_name(base_name);
-
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
-    let shell_cmd = claude_shell_command(
+    let line = claude_command_line(
         resume_session_id,
         yolo,
         custom_command,
         custom_prefix,
-        &shell,
         &window_name,
     );
 
-    let id = new_window(&window_name, path, Some(&shell_cmd))?;
-    // Belt and braces: the prelude above is what orders the stamp correctly,
-    // this covers a shell that never ran it. Same value either way.
-    stamp_birth_name(&id, &window_name);
-    Some(window_name)
+    match prepare_startup(&window_name, &line) {
+        // The window's command is the user's shell, interactive, reading a
+        // startup file that ends in the Claude command. Nothing is typed, so
+        // there is nothing to race the shell's startup.
+        Some(startup) => {
+            let id = new_window(&window_name, path, Some(&startup.command))?;
+            // Belt and braces: the stamp inside the startup file is what
+            // orders it correctly, this covers a shell that never read it.
+            // Same value either way.
+            stamp_birth_name(&id, &window_name);
+            Some(window_name)
+        }
+        // A shell with no startup hook we know. The window runs the plain
+        // default shell and the line is typed into it — stamped first, which
+        // orders it: Claude cannot reach its first hook until keys that have
+        // not been sent yet arrive.
+        None => {
+            let id = new_window(&window_name, path, None)?;
+            stamp_birth_name(&id, &window_name);
+            send_line(&id, &line).then_some(window_name)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -539,43 +728,22 @@ mod tests {
         );
     }
 
-    /// What the shell actually receives, with both layers of quoting undone.
-    fn decoded(built: &str, shell: &str) -> String {
-        let payload = built
-            .strip_prefix(&format!("{shell} -ic "))
-            .unwrap_or_else(|| panic!("unexpected shape: {built}"));
-        let mut parts = shlex::split(payload).expect("a single quoted argument");
-        assert_eq!(parts.len(), 1, "not one argument: {payload}");
-        parts.remove(0)
-    }
-
     #[test]
     fn claude_command_building() {
-        let stamp = "tmux set-option -w @claude_birth_name 'claude:wt'";
-        let build = |resume, yolo, cmd, prefix| {
-            decoded(
-                &claude_shell_command(resume, yolo, cmd, prefix, "/bin/zsh", "claude:wt"),
-                "/bin/zsh",
-            )
-        };
+        let build =
+            |resume, yolo, cmd, prefix| claude_command_line(resume, yolo, cmd, prefix, "claude:wt");
 
         // A fresh session is named at launch; a resumed one keeps its own name.
-        assert_eq!(
-            build(None, false, None, None),
-            format!("{stamp}; claude -n 'claude:wt'")
-        );
+        assert_eq!(build(None, false, None, None), "claude -n 'claude:wt'");
         assert_eq!(
             build(None, true, None, None),
-            format!("{stamp}; claude --dangerously-skip-permissions -n 'claude:wt'")
+            "claude --dangerously-skip-permissions -n 'claude:wt'"
         );
-        assert_eq!(
-            build(Some("abc123"), false, None, None),
-            format!("{stamp}; claude -r abc123")
-        );
+        assert_eq!(build(Some("abc123"), false, None, None), "claude -r abc123");
         // A custom button never gets the YOLO flag appended.
         assert_eq!(
             build(None, true, Some("claude --model opus"), Some("opus")),
-            format!("{stamp}; claude --model opus -n 'claude:wt'")
+            "claude --model opus -n 'claude:wt'"
         );
     }
 
@@ -610,13 +778,118 @@ mod tests {
             "a window name executed a command"
         );
 
-        // And the name is still literal after the second layer of quoting.
-        let built = claude_shell_command(None, false, None, None, "/bin/sh", "$(id); rm -rf /");
+        // And the name is still literal in the line the window is given.
         assert_eq!(
-            decoded(&built, "/bin/sh"),
-            "tmux set-option -w @claude_birth_name '$(id); rm -rf /'; \
-             claude -n '$(id); rm -rf /'"
-                .replace("\\\n             ", "")
+            claude_command_line(None, false, None, None, "$(id); rm -rf /"),
+            "claude -n '$(id); rm -rf /'"
         );
+    }
+
+    /// The line becomes one line of a file a shell reads, so a newline in it
+    /// would end that line and leave the rest standing as a command of its
+    /// own — from a window name forestui did not write. Control characters
+    /// never survive that far.
+    #[test]
+    fn a_newline_in_a_name_cannot_smuggle_a_command() {
+        let built = claude_command_line(None, false, None, None, "wt'\nrm -rf /\n#");
+        assert!(!built.contains('\n'), "a newline survived: {built:?}");
+        assert_eq!(built, "claude -n 'wt'\\''rm -rf /#'");
+    }
+
+    fn home() -> ShellHome {
+        ShellHome {
+            home: "/home/u".into(),
+            zdotdir: None,
+            env_file: None,
+        }
+    }
+
+    /// Each hook replaces one of the user's own startup files, so each
+    /// generated file has to source the file it displaced. Getting this wrong
+    /// is invisible until someone's aliases or PATH quietly stop applying in
+    /// Claude windows only.
+    #[test]
+    fn a_generated_startup_file_sources_the_one_it_replaced() {
+        let dir = Path::new("/tmp/launch");
+        let tail = startup_tail("claude:wt", "claude");
+        let tail = tail.as_str();
+
+        let zsh =
+            startup_for("/usr/bin/zsh", dir, &home(), "claude:wt", "claude").expect("zsh is known");
+        assert_eq!(zsh.command, "env ZDOTDIR='/tmp/launch' '/usr/bin/zsh' -i");
+        let names: Vec<_> = zsh.files.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(names, vec![dir.join(".zshenv"), dir.join(".zshrc")]);
+        assert!(zsh.files[0].1.contains("'/home/u/.zshenv'"));
+        // ZDOTDIR is put back before the user's own file runs.
+        assert!(zsh.files[1].1.starts_with("ZDOTDIR='/home/u'\n"));
+        assert!(zsh.files[1].1.contains("'/home/u/.zshrc'"));
+        assert!(zsh.files[1].1.ends_with(tail));
+
+        let bash =
+            startup_for("/bin/bash", dir, &home(), "claude:wt", "claude").expect("bash is known");
+        assert_eq!(bash.command, "'/bin/bash' --rcfile '/tmp/launch/rc' -i");
+        assert!(bash.files[0].1.contains("'/home/u/.bashrc'"));
+        assert!(bash.files[0].1.ends_with(tail));
+
+        let sh =
+            startup_for("/bin/dash", dir, &home(), "claude:wt", "claude").expect("dash is known");
+        assert_eq!(sh.command, "env ENV='/tmp/launch/rc' '/bin/dash' -i");
+        assert!(sh.files[0].1.ends_with(tail));
+
+        // The command lands in the shell's history where there is a builtin
+        // for it, so the up arrow restarts a session that was interrupted.
+        assert!(zsh.files[1].1.contains("print -s -- 'claude'"));
+        assert!(bash.files[0].1.contains("history -s 'claude'"));
+        assert!(!sh.files[0].1.contains("history"));
+
+        // A shell whose ENV already names a file keeps reading it.
+        let inherited = ShellHome {
+            env_file: Some("/home/u/.shinit".into()),
+            ..home()
+        };
+        let sh =
+            startup_for("/bin/sh", dir, &inherited, "claude:wt", "claude").expect("sh is known");
+        assert!(sh.files[0].1.contains("'/home/u/.shinit'"));
+    }
+
+    /// Every generated file removes itself once the shell has it, so a session
+    /// left open for a week does not leave one behind.
+    #[test]
+    fn a_generated_startup_file_sweeps_itself_up() {
+        let dir = Path::new("/tmp/launch");
+        for shell in ["/usr/bin/zsh", "/bin/bash", "/bin/sh"] {
+            let startup =
+                startup_for(shell, dir, &home(), "claude:wt", "claude").expect("a known shell");
+            let last = &startup.files.last().expect("a file").1;
+            assert!(
+                last.contains("rm -rf '/tmp/launch'"),
+                "{shell} leaves its startup file behind: {last:?}"
+            );
+        }
+    }
+
+    /// An unknown shell is not a failure — the line is typed into a plain
+    /// shell instead, which needs no hook at all.
+    #[test]
+    fn an_unknown_shell_falls_back_to_typing() {
+        let call = |shell| startup_for(shell, Path::new("/tmp/l"), &home(), "claude:wt", "claude");
+        assert!(call("/usr/bin/fish").is_none());
+        assert!(call("/usr/bin/nu").is_none());
+    }
+
+    /// The stamp goes in ahead of the command, from inside the window: the
+    /// shell starts Claude on its own, so a stamp sent after `new-window`
+    /// returns can lose the race to Claude's first hook.
+    #[test]
+    fn the_startup_file_stamps_before_it_launches() {
+        let tail = startup_tail("yolo:wt", "claude -n 'yolo:wt'");
+        let stamp = tail.find("@claude_birth_name").expect("a stamp");
+        let monitor = tail.find("set -m").expect("job control");
+        let launch = tail.find("claude -n").expect("the command");
+        assert!(
+            stamp < monitor && monitor < launch,
+            "out of order: {tail:?}"
+        );
+        assert!(tail.contains("@claude_birth_name 'yolo:wt'"));
     }
 }


### PR DESCRIPTION
A Claude window's command was `$SHELL -ic 'claude …'`, so the shell existed only
to launch Claude and exited with it. That left two ways to lose a conversation:

- **Ctrl-C** killed Claude and took the window with it.
- **Ctrl-Z** — which Claude now binds to suspend — stopped the process with no
  shell left to `fg` it back. The session became unreachable and the pane
  frozen; the only way out was closing the window, losing the session.

The window now runs the user's shell interactively and Claude is one of its
**jobs**. Ctrl-C and Ctrl-Z both land at a prompt, where `fg` resumes and the up
arrow restarts.

## Inline, not typed

The command is not typed into the window. It is written into a startup file
forestui generates and points the shell at, so it is already there when the
shell reads it — nothing to race, nothing to arrive half-read.

| shell | pointed at with | replaces, so sources back |
|---|---|---|
| zsh | `ZDOTDIR=<dir>` | `.zshenv` + `.zshrc` |
| bash | `--rcfile <file>` | `.bashrc` |
| sh, dash, ksh, mksh, ash, yash | `ENV=<file>` | whatever `ENV` already named |

The shell is interactive and non-login — exactly what `$SHELL -ic` was — so a
Claude window's environment is unchanged from before. The generated files delete
themselves once read.

Three lines in that file carry weight:

- **`set -m`.** Without it a command run from a startup file is not a job: bash
  hands it the shell's own ignored `SIGTSTP`, so Ctrl-Z does nothing at all and
  the window wedges with no way back (reproduced, and unrecoverable). zsh already
  runs interactive shells this way; saying so makes the file mean the same thing
  under every shell.
- **The birth stamp goes back inside the window**, ahead of the command — the
  shell starts Claude on its own, so a stamp sent after `new-window` returns can
  lose the race to Claude's first hook.
- **The command is pushed into shell history** (`print -s`, `history -s`), which
  typing would have done for free. After an accidental Ctrl-C the up arrow is the
  shortest way back.

fish, nushell and anything else with no hook tested here fall back to typing the
line with `send-keys` — no per-shell knowledge needed. Its weakness is why it is
not the default: keystrokes sent before the shell is ready wait in the terminal,
and a startup that *consumes* input (zsh-newuser-install in a bare `HOME` is a
real example) eats them.

## The trade

The window no longer closes when Claude exits; it drops to a prompt, like any
other terminal.

## Testing

Job control was proven in zsh, bash and dash before any code was written.

Driven end-to-end through real forestui with a stub that self-suspends the way
Claude Code does, under a zsh whose `.zshrc` defines an **alias** for `claude`:

- launch showed `--via-alias`, so the user's config really is sourced
- self-suspend → `zsh: suspended` → prompt → `jobs` lists it → `fg` → keys work
- Ctrl-C → prompt, shell alive; up arrow recalls the command
- `.zshenv` and `.zshrc` both ran, `ZDOTDIR` restored before the user's config
  saw it, birth stamp correct, zero leftover temp dirs
- New Session, YOLO, a custom button and Resume (`-r <id>`, no `-n`) all correct

Sweep: 22/22 assertions pass, 0 wait timeouts, and **every committed frame is
unchanged** — the mechanism is invisible on screen and completely different
beneath. New UC-98 guards it: interrupt the stub, then ask the shell a question
only a live shell can answer.

`make check` and `make check-shipped` clean; 233 unit tests, including new ones
covering the generated files (sourcing, self-cleanup, history line, stamp
ordering, unknown-shell fallback). Rebased on #52 and re-verified against it:
sweep re-run with zero baseline drift, and `scripts/terminal-modes-probe.py`
passes on the merged build.