### PR TITLE
Rename stopped sessions with the agent-name record too, so resume draws it

### DIFF
--- a/src/services/claude_session.rs
+++ b/src/services/claude_session.rs
@@ -485,7 +485,7 @@ pub fn parse_session_file(file_path: &Path) -> Option<ClaudeSession> {
     })
 }
 
-/// Name a session by appending the same record Claude's own `/rename` writes.
+/// Name a session by appending the same records Claude's own `/rename` writes.
 ///
 /// The parser takes the last `custom-title` record stamped with the file's own
 /// session id, so appending is the whole operation — nothing is rewritten, and
@@ -493,6 +493,14 @@ pub fn parse_session_file(file_path: &Path) -> Option<ClaudeSession> {
 /// with no live window: Claude holds a live transcript open and interleaving
 /// appends with its writer is not a race worth having when renaming the tmux
 /// window does the same job through the sync plugin.
+///
+/// Claude keeps a session's name in *two* record types and a runtime rename
+/// writes them as a pair: `custom-title` is the session title (the resume
+/// picker, hook-input `session_title`), `agent-name` is what the badge in the
+/// prompt box draws. Appending only the title looked renamed everywhere except
+/// the resumed UI itself — and the sync plugin could not heal it, because the
+/// title it compares against the window was already correct, so it never
+/// pushed the runtime rename that would have rewritten the agent name.
 pub fn rename_session(path: &str, session_id: &str, name: &str) -> Result<(), String> {
     let file = claude_projects_dir()
         .join(path_to_claude_folder(path))
@@ -505,17 +513,22 @@ pub fn rename_transcript(file: &Path, session_id: &str, name: &str) -> Result<()
     if !file.exists() {
         return Err("Session transcript no longer exists".to_string());
     }
-    let record = serde_json::json!({
+    let title = serde_json::json!({
         "type": "custom-title",
         "customTitle": name,
         "sessionId": session_id,
     });
-    let line = format!("{record}\n");
+    let agent_name = serde_json::json!({
+        "type": "agent-name",
+        "agentName": name,
+        "sessionId": session_id,
+    });
+    let lines = format!("{title}\n{agent_name}\n");
     use std::io::Write;
     std::fs::OpenOptions::new()
         .append(true)
         .open(file)
-        .and_then(|mut f| f.write_all(line.as_bytes()))
+        .and_then(|mut f| f.write_all(lines.as_bytes()))
         .map_err(|error| error.to_string())
 }
 
@@ -994,9 +1007,11 @@ mod tests {
         assert_eq!(fmt_cost(123.4), "~$123");
     }
 
-    /// Renaming a stopped session appends the record `/rename` writes, so the
-    /// next parse — every consumer — sees the new name. An empty transcript
-    /// path errors instead of creating a stray file.
+    /// Renaming a stopped session appends the records `/rename` writes — the
+    /// `custom-title`/`agent-name` pair — so the next parse sees the new name
+    /// and a resumed Claude draws it in its badge, which renders the agent
+    /// name, not the title. An empty transcript path errors instead of
+    /// creating a stray file.
     #[test]
     fn renaming_a_stopped_session_appends_a_title_record() {
         let dir = tempfile::tempdir().unwrap();
@@ -1012,6 +1027,23 @@ mod tests {
         let session = parse_session_file(&file).expect("a session");
         assert_eq!(session.custom_title.as_deref(), Some("my rename"));
         assert_eq!(session.title, "my rename");
+
+        // Both records land, stamped with the session id, each a valid JSON
+        // line — a torn or concatenated line would be skipped by every parser.
+        let raw = std::fs::read_to_string(&file).unwrap();
+        let records: Vec<serde_json::Value> = raw
+            .lines()
+            .skip(1)
+            .map(|line| serde_json::from_str(line).expect("each appended line parses alone"))
+            .collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["type"], "custom-title");
+        assert_eq!(records[0]["customTitle"], "my rename");
+        assert_eq!(records[1]["type"], "agent-name");
+        assert_eq!(records[1]["agentName"], "my rename");
+        for record in &records {
+            assert_eq!(record["sessionId"], "sess-r");
+        }
 
         // A missing transcript is an error, not a new file.
         assert!(rename_session("/nowhere/forestui-rename-test", "ghost", "x").is_err());

--- a/src/services/claude_session.rs
+++ b/src/services/claude_session.rs
@@ -523,12 +523,27 @@ pub fn rename_transcript(file: &Path, session_id: &str, name: &str) -> Result<()
         "agentName": name,
         "sessionId": session_id,
     });
-    let lines = format!("{title}\n{agent_name}\n");
-    use std::io::Write;
+    use std::io::{Read, Seek, SeekFrom, Write};
     std::fs::OpenOptions::new()
+        .read(true)
         .append(true)
         .open(file)
-        .and_then(|mut f| f.write_all(lines.as_bytes()))
+        .and_then(|mut f| {
+            // A transcript normally ends in a newline, but a torn tail (a
+            // crashed writer) must not swallow the rename: appended straight
+            // onto an unterminated line, the first record and that line both
+            // stop parsing while the second still lands — the exact
+            // title/badge disagreement this function exists to prevent.
+            let mut needs_newline = false;
+            if f.metadata()?.len() > 0 {
+                let mut last = [0u8; 1];
+                f.seek(SeekFrom::End(-1))?;
+                f.read_exact(&mut last)?;
+                needs_newline = last[0] != b'\n';
+            }
+            let prefix = if needs_newline { "\n" } else { "" };
+            f.write_all(format!("{prefix}{title}\n{agent_name}\n").as_bytes())
+        })
         .map_err(|error| error.to_string())
 }
 
@@ -1048,6 +1063,37 @@ mod tests {
         // A missing transcript is an error, not a new file.
         assert!(rename_session("/nowhere/forestui-rename-test", "ghost", "x").is_err());
         assert!(delete_session("/nowhere/forestui-rename-test", "ghost").is_err());
+    }
+
+    /// A transcript whose last line was torn mid-write (no trailing newline)
+    /// still takes the rename: appending blindly would fuse the first record
+    /// onto the torn line and lose it, leaving the pair half-applied.
+    #[test]
+    fn renaming_survives_a_transcript_with_a_torn_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("sess-t.jsonl");
+        std::fs::write(
+            &file,
+            "{\"type\":\"user\",\"timestamp\":\"2026-08-01T10:00:00Z\",\
+              \"message\":{\"content\":\"hello\"}}\n\
+             {\"type\":\"assistant\",\"truncated",
+        )
+        .unwrap();
+
+        rename_transcript(&file, "sess-t", "after the tear").expect("the append lands");
+        let session = parse_session_file(&file).expect("a session");
+        assert_eq!(session.custom_title.as_deref(), Some("after the tear"));
+
+        let raw = std::fs::read_to_string(&file).unwrap();
+        let tail: Vec<&str> = raw.lines().rev().take(2).collect();
+        assert!(
+            tail[1].starts_with("{\"customTitle\""),
+            "title on its own line"
+        );
+        assert!(
+            tail[0].starts_with("{\"agentName\""),
+            "agent name on its own line"
+        );
     }
 
     /// Pins outrank recency, in pin order; everything else stays newest-first.


### PR DESCRIPTION
## The bug

Rename a **stopped** Claude session in forestui, resume it: the tmux tab carries the new name, but the Claude prompt-box badge keeps the old one — and no amount of chatting realigns them. Only renaming the tab a *second* time fixed it.

## Root cause

Claude Code keeps a session's name in **two** transcript records, written as a pair by every runtime rename (`/rename`, or the sync plugin's `sessionTitle` push):

- `custom-title` — the session title: the resume picker, hook-input `session_title`
- `agent-name` — what the badge in the prompt box draws

forestui's stopped-session rename appended only `custom-title`. On resume the title was right everywhere *except* the visible badge — and the sync plugin could not heal it, because the title it compares against the window name was already the new name, so all three strings it can see agreed and it never pushed the runtime rename that rewrites the agent name. A second tab rename broke the tie (`window != @claude_synced_name`), which is why that worked.

Diagnosed from a real repro transcript: forestui's appended record is identifiable by serde_json's alphabetical key order, and the working second rename is the only one followed by an `agent-name` record.

## The fix

- `rename_transcript` now appends the same `custom-title` + `agent-name` pair Claude writes, so a resumed session draws the new name from its first frame.
- Hardening from adversarial review: if the transcript's last line is torn (no trailing newline), lead with one — appending blindly would fuse the first record onto the torn line and half-apply the pair, recreating the exact disagreement this fixes.

## Testing

- Unit tests assert both records land as valid standalone JSON lines stamped with the session id, plus the torn-tail case; `make check` and `make check-shipped` green.
- Live tu-driven repro (isolated tmux + real Claude): fresh session `claude:demo` → stop → rename in forestui to `claude:demoRENAMED` → resume: badge and tab both show the new name immediately, stable across turns; a subsequent tab rename still syncs to the session on the next turn, so the normal two-way path is unregressed.

Sessions renamed-while-stopped before this fix heal on their next tab rename, as before; nothing to migrate.