### PR TITLE
Refuse focus, not just activation, on a click over a disabled control

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2872,7 +2872,9 @@ mod tests {
 
     /// A control the frame drew as disabled must not fire — from the mouse or
     /// from Enter. The greyed-out `↓ Git Pull (No remote)` used to run `git
-    /// pull` anyway and answer with an error toast.
+    /// pull` anyway and answer with an error toast. A click must not take
+    /// focus either: a focused control renders with the full accent style, so
+    /// moving the cursor there made a disabled `[Del]` light up as if it ran.
     #[tokio::test]
     async fn a_disabled_control_does_not_activate() {
         let (_dir, mut app) = app_with_fixture();
@@ -2892,6 +2894,7 @@ mod tests {
         app.push_hit(rect(40, 5, 12, 1), HitTarget::DetailItem(index));
         app.handle_mouse(click(45, 5));
         assert!(app.notifications.is_empty(), "the click ran the action");
+        assert_eq!(app.focus, Focus::Sidebar, "the click focused the control");
 
         app.focus = Focus::Detail;
         app.detail_index = index;
@@ -2955,6 +2958,7 @@ mod tests {
         let (_dir, mut app) = app_with_fixture();
         app.handle_key(key(KeyCode::Down));
         app.sessions = Some(Vec::new());
+        snapshot_drawn(&mut app);
 
         let index = app
             .detail_items()

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -273,18 +273,23 @@ impl App {
             // point of recording it is that the control beneath does not run.
             HitTarget::Notification => {}
             HitTarget::DetailItem(index) => {
-                self.focus = Focus::Detail;
-                self.detail_index = index;
-                self.detail_follow_focus = true;
                 // Resolve against the drawn snapshot, not a re-derived list: a
                 // background event drained in this same batch can have grown
                 // the live list, remapping this index onto a different control
                 // than the one the click landed on. A disabled control keeps
-                // its slot but must not fire.
-                if let Some((DetailItem::Action(action), enabled)) =
-                    self.drawn_items.get(index).cloned()
-                    && enabled
-                {
+                // its slot but a click on it is inert entirely — taking focus
+                // would paint it with the full accent style, indistinguishable
+                // from an enabled control that just ran.
+                let Some((item, enabled)) = self.drawn_items.get(index).cloned() else {
+                    return;
+                };
+                if !enabled {
+                    return;
+                }
+                self.focus = Focus::Detail;
+                self.detail_index = index;
+                self.detail_follow_focus = true;
+                if let DetailItem::Action(action) = item {
                     self.run_action(action);
                 }
             }


### PR DESCRIPTION
Clicking a disabled detail-pane control (e.g. the greyed-out `[Del]` on a live Claude session) did not run the action, but it still moved detail focus onto the control. A focused control renders with the full accent style whether or not it is enabled, so the disabled button lit up as if it had activated — a purely visual lie.

A click on a control drawn as disabled is now inert entirely: it neither fires nor takes focus, matching how the Textual build treated disabled widgets. Keyboard navigation is unchanged — the cursor can still pass over and rest on a disabled control, where the legible focused style is deliberate.

The click resolves against the `drawn_items` snapshot before touching focus, for the same reason activation always did: the snapshot is the frame the user clicked on.

Verified with `tu`: clicking `↓ Git Pull (No remote)` leaves it grey with focus untouched; clicking the enabled `Add Worktree` still opens the modal. `make check` passes; the existing `a_disabled_control_does_not_activate` test now also asserts focus stays put.